### PR TITLE
Adds the ability to disable animations on select.

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,9 @@ Tree.prototype.resize = function () {
   this.node.call(this.resizer)
 }
 
-Tree.prototype.draw = function (source) {
+Tree.prototype.draw = function (source, opt) {
+  opt = opt || {}
+
   var self = this
 
   this.node = this.node.data(this.tree.nodes(this._nodeData[0]), function (d) {
@@ -151,6 +153,9 @@ Tree.prototype.draw = function (source) {
   // Now the indicator light
   enter.append('div')
           .attr('class', 'indicator')
+
+  // disable animations if necessary
+  this.node.classed('notransition', opt.animate === false)
 
   // Update the color if it changed
   this.node.selectAll('div.indicator')
@@ -204,6 +209,13 @@ Tree.prototype.draw = function (source) {
 
   // Now resize things
   this.resize()
+
+  // Now remove the notransition class
+  if (opt.animate === false) {
+    process.nextTick(function () {
+      self.node.classed('notransition', false)
+    })
+  }
 }
 
 Tree.prototype.select = function (id, opt) {
@@ -283,9 +295,9 @@ Tree.prototype._onSelect = function (d, i, j, opt) {
   })(d.parent)
 
   if (toggle) {
-    this.toggle(d)
+    this.toggle(d, opt)
   } else {
-    this.draw(d)
+    this.draw(d, opt)
   }
 
   if (!opt.silent) {
@@ -347,7 +359,7 @@ Tree.prototype.collapseAll = function () {
   })
 }
 
-Tree.prototype.toggle = function (d) {
+Tree.prototype.toggle = function (d, opt) {
   if (d.children) {
     d._children = d.children
     d.children = null
@@ -355,7 +367,7 @@ Tree.prototype.toggle = function (d) {
     d.children = d._children
     d._children = null
   }
-  this.draw(d)
+  this.draw(d, opt)
 }
 
 module.exports = Tree

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -37,6 +37,22 @@ test('selects a node', function (t) {
   }, 400)
 })
 
+test('selects a node without animations', function (t) {
+  var tree = new Tree({stream: stream()}).render()
+    , tick = process.nextTick
+
+  process.nextTick = function (fn) {
+    process.nextTick = tick // back to normal
+
+    t.ok(tree.node.classed('notransition'), 'tree nodes have notransition class applied')
+    fn()
+    t.ok(!tree.node.classed('notransition'), 'tree nodes notransition class removed')
+    tree.el.remove()
+    t.end()
+  }
+  tree.select(1003, {animate: false})
+})
+
 test('select will not toggle an already expanded node', function (t) {
   var tree = new Tree({stream: stream()}).render()
 

--- a/tree.less
+++ b/tree.less
@@ -40,6 +40,13 @@
         overflow-x: hidden;
         .lh-transition(transform @transition, opacity @transition);
 
+        &.notransition {
+          .lh-transition(none) !important;
+          .node-contents {
+            .lh-transition(none) !important;
+          }
+        }
+
         .node-contents {
           margin: 6px;
           text-align: left;


### PR DESCRIPTION
To disable animations, invoke select with animate: false.
e.g.

```
tree.select(1004, {animate: false})
```

Fixes #66
