### PR TITLE
Stores internal _nodeData as sparse array.

### DIFF
--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -7,8 +7,8 @@ var test = require('tape').test
 test('get', function (t) {
   var tree = new Tree({stream: stream()}).render()
 
-  t.deepEqual(tree.get(), tree._nodeData[0], 'get returns root by default')
-  t.deepEqual(tree.get(1002), tree._nodeData[0].children[0], 'get returns a node by id')
+  t.deepEqual(tree.get(), tree.root, 'get returns root by default')
+  t.deepEqual(tree.get(1002), tree.root.children[0], 'get returns a node by id')
   t.ok(tree.get(1006), 'get returns nodes that are hidden')
   tree.el.remove()
   t.end()

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -6,7 +6,7 @@ var test = require('tape').test
 
 test('render populates data from stream', function (t) {
   var tree = new Tree({stream: stream()}).render()
-  t.equal(tree._nodeData.length, data.length, '_nodeData contains all data')
+  t.equal(Object.keys(tree._nodeData).length, data.length, '_nodeData contains all data')
   tree.el.remove()
   t.end()
 })


### PR DESCRIPTION
The key is the node id and the value is the node. When we remove nodes,
this will be easier/faster to sync _nodeData. Additionally, getting a
node's parent will be much faster as we're building the tree.

An object could also be used, and might be faster, but I don't think
this is something that will be noticable. The array gives us some extra
convenience from a code standpoint, and we can always optimize later.

But it won't be a problem for <100K nodes I'm sure.
