### PR TITLE
Adds 'transitioning-node' class applied to nodes during a transition

### DIFF
--- a/lib/enter.js
+++ b/lib/enter.js
@@ -3,9 +3,10 @@ var partialRight = require('./partial-right')
 module.exports = function (tree) {
 
   return function (selection, transformStyle, cssClasses) {
-    var enter = selection.enter()
+    var transitions = !tree.el.select('.tree').classed('notransition')
+      , enter = selection.enter()
                          .append('li')
-                           .attr('class', 'node ' + (cssClasses || ''))
+                           .attr('class', 'node ' + (cssClasses || '') + (transitions ? ' transitioning-node' : ''))
                            .on('click', partialRight(tree._onSelect.bind(tree), tree.options))
                            .style(tree.prefix + 'transform', transformStyle)
                            .style('opacity', 1e-6)
@@ -39,6 +40,13 @@ module.exports = function (tree) {
 
     tree._forceRedraw()
 
+    // Remove transitioning-node once the transitions have ended
+    if (transitions) {
+      d3.timer(function () {
+        selection.classed('transitioning-node', false)
+        return true // run once
+      }, tree.transitionTimeout)
+    }
     return selection
   }
 }

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -159,6 +159,25 @@ test('renders without transitions', function (t) {
   })
 })
 
+test('transitioning-node applied to entering nodes', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s})
+
+  s.on('end', function () {
+    process.nextTick(function () {
+      var node = tree._layout[1002]
+      t.ok(node._children, 'first child has hidden children')
+      tree.node[0][1].click() // click the first child
+      t.equal(tree.el.selectAll('li.node.transitioning-node').size(), 5, '5 new nodes have transitioning-node')
+      setTimeout(function () {
+        t.equal(tree.el.selectAll('li.node.transitioning-node').size(), 0, 'transitioning-node has been removed')
+        t.end()
+      }, 400)
+    })
+  })
+  tree.render()
+})
+
 test('disables animations if opts.maxAnimatable is exceeded', function (t) {
   var s = stream()
     , tree = new Tree({stream: s, maxAnimatable: 3}).render()

--- a/tree.less
+++ b/tree.less
@@ -67,6 +67,10 @@
         overflow-x: hidden;
         .lh-transition(transform @transition, opacity @transition, height @transition);
 
+        &.transitioning-node {
+          pointer-events: none;
+        }
+
         .node-contents {
           margin: 6px;
           margin-left: -6px;


### PR DESCRIPTION
Disables pointer events so you can't click on a node that's moving.

Fixes #126
