### PR TITLE
Explicity set scrollTop on the tree, rather than scrollIntoView

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,15 +282,11 @@ Tree.prototype.select = function (id, opt) {
 
     if (d._y < n.scrollTop || d._y > n.offsetHeight + n.scrollTop) {
       // Now scroll the node into view
-      var node = this.node.filter(function (_d) {
-        return _d == d
-      }).node()
-
       if (opt.animate === false || !this._hasTransitions()) {
-        node.scrollIntoView()
+        n.scrollTop = d._y
       } else {
         d3.timer(function () {
-          node.scrollIntoView()
+          n.scrollTop = d._y
           return true
         }, this.transitionTimeout)
       }


### PR DESCRIPTION
Fixes #131

I couldn't reproduce this, so there's some scoreboard css that's causing it. But this fix might get you closer since it explicitly sets the scrollTop on the tree node rather than allowing the browser to do its own thing. It's also a bit more efficient, which is nice.

I'd say if there's still a bug after you update your code, it warrants exploration in scoreboard css land.
