### PR TITLE
Issue 146

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -42,7 +42,7 @@ Dnd.prototype._createTraveler = function (d, i, node) {
                  _source: d,
                  _initialY: d._y,
                  _initialParent: d.parent && d.parent.id,
-                 _initialIndex: d.parent && d.parent.children.indexOf(d),
+                 _initialIndex: d.parent && d.parent._allChildren.indexOf(d),
                  i: i,
                  embedded: false
                })
@@ -115,7 +115,6 @@ Dnd.prototype._drag = function (d, i, node) {
       dropzone = d3.select(self.tree.node[0][Math.max(d.i, 0)]).datum()
     }
 
-
     if (d._y % (before._y + (self.tree.options.height / 2)) <= threshold) {
       embed = true
     }
@@ -130,11 +129,20 @@ Dnd.prototype._drag = function (d, i, node) {
     }
 
     if (ci || d.embedded != embed) {
+
+      // Clean up previous _collapsedChildren on the last parent
+      if (source.parent && source.parent._collapsedChildren) {
+        source.parent._allChildren = source.parent._collapsedChildren
+        source.parent._collapsedChildren = null
+        source.parent.collapsed = true
+      }
+
+      // Remove the node from its previous parent
       if (self.tree.options.forest && !source.parent) {
         // forest tree w/ no parent means this goes as a new root
         self.tree.root.splice(self.tree.root.indexOf(source), 1)
       } else {
-        source.parent.children.splice(source.parent.children.indexOf(source), 1)
+        source.parent._allChildren.splice(source.parent._allChildren.indexOf(source), 1)
       }
 
       var newParent = embed ? before : dropzone.parent
@@ -151,8 +159,14 @@ Dnd.prototype._drag = function (d, i, node) {
       if (!newParent) {
         source.parent = null
         children = self.tree.root
+      } else if (newParent.collapsed && newParent._allChildren) {
+        // Dropping onto a collapsed node with children.
+        newParent._collapsedChildren = newParent._allChildren
+        children = newParent._allChildren = []
+        newParent.collapsed = false
       } else {
-        children = newParent.children || (newParent.children = [])
+        children = newParent._allChildren || (newParent._allChildren = [])
+        newParent.collapsed = false
       }
 
       var idx = children.length ? children.indexOf(dropzone) : 0
@@ -196,16 +210,16 @@ Dnd.prototype._end = function (d, i, node) {
 
   if (this.traveler) {
     if (this.traveler.datum()._initialY !== d._y) {
-      if (d.parent && d.parent._children && d.parent.children) {
+      if (d.parent && d.parent._collapsedChildren) {
         // The node was dropped onto another node that had hidden children, expand the new drop location
-        d.parent.children = d.parent._children.concat(d.parent.children[0])
-        d.parent._children = null
+        d.parent._allChildren = d.parent._collapsedChildren.concat(d.parent._allChildren[0])
+        d.parent._collapsedChildren = null
         this.tree._fly(d.parent)
       }
       this.tree.emit('move', this.tree.nodes[d.id],
                              d.parent ? this.tree.nodes[d.parent.id] : null,
                              this.tree.nodes[this.traveler.datum()._initialParent],
-                             d.parent ? d.parent.children.indexOf(d) : this.tree.root.indexOf(d),
+                             d.parent ? d.parent._allChildren.indexOf(d) : this.tree.root.indexOf(d),
                              this.traveler.datum()._initialIndex)
     }
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -20,7 +20,7 @@ module.exports = function (tree) {
       // change the state of the toggle icon by adjusting its class
       node.select('.toggler')
                .attr('class', function (d) {
-                 return 'toggler ' + (d._children ? 'collapsed' : d.children ? 'expanded' : 'leaf')
+                 return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
                })
 
       // Perhaps the name changed


### PR DESCRIPTION
@mattsgarlata This isn't ready yet. I'm struggling with a few more changes, but I wanted to get a second opinion before I keep pushing through with this change. 
#146 and #147 are kind of tough because of moving node's to `_invisibleNodes` based on scoreboard setting the `visible` property. This changes things so the tree maintains a single array `_allChildren` and then sets an accessor function telling d3 how to determine if the tree has children that are visible. That's done here:  https://github.com/SpiderStrategies/scoreboard-tree/blob/59f841e18ca25024279c09f2bf96ca46076eb821/index.js#L70-77

Generally I think it cleans up the code as you can see from the big red block in index.js where we initially build the tree, but again, I'd like a second opinion before I figure out the remaining issues and bugs, especially with dnd.
