### PR TITLE
Allows null `to` on copy, which means new root node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,12 +349,20 @@ Tree.prototype._descendants = function (node) {
 /*
  * Copies a node to some new parent. `transformer` can be used to transform
  * each node that will be copied.
+ *
+ * If to is missing and the tree is a forest, the node will be copied
+ * to a new root node of the forest tree.
  */
 Tree.prototype.copy = function (node, to, transformer) {
   var _node = this._layout[typeof node === 'object' ? node.id : node]
 
   if (!_node) {
     return
+  }
+
+  if (!transformer) {
+    transformer = to
+    to = undefined
   }
 
   // We need a clone of the node and the layout

--- a/test/forest-tree-test.js
+++ b/test/forest-tree-test.js
@@ -115,6 +115,23 @@ test('root nodes return their siblings', function (t) {
   })
 })
 
+test('copies a node to a new root', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s, forest: true}).render()
+
+  t.equal(tree.root.length, 2, 'two root nodes')
+  tree.copy(1003, function (n) {
+    n.id *= 100
+    return n
+  })
+
+  process.nextTick(function () {
+    t.equal(tree.root.length, 3, 'three root nodes')
+    t.deepEqual(tree.root[2], tree._layout[100300], 'last root node is 100300')
+    t.end()
+  })
+})
+
 test('moves a node to a new root', function (t) {
   var s = stream()
     , tree = new Tree({stream: s, forest: true}).render()


### PR DESCRIPTION
I'm writing a test, so don't merge yet.

Fixes #168 
