### PR TITLE
Replaces less w/ sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 example/bundle.js
 npm-debug.log
 example/.bundle.js
+.sass-cache
+dist

--- a/example/server.js
+++ b/example/server.js
@@ -3,6 +3,7 @@ var http = require('http')
   , url = require('url')
   , d3 = require('d3')
   , tree = require('./tree')
+  , sass = require('node-sass')
   , request = require('request')
   , spawn = require('child_process').spawn
 
@@ -13,10 +14,13 @@ http.createServer(function (req, res) {
   if (path == '/index.html' || path == '/') {
     return fs.createReadStream(__dirname + '/index.html').pipe(res)
   } else if (path == '/tree.css') {
-    res.writeHead(200, { 'Content-Type': 'text/css' })
-    var less = spawn('./node_modules/less/bin/lessc', ['-x', 'tree.less'])
-    less.stdout.pipe(res)
-    less.stderr.pipe(process.stderr)
+    sass.render({
+        file: './tree.scss',
+        includePaths: ['./node_modules/bourbon/app/assets/stylesheets/' ]
+      }, function (err, result) {
+      res.writeHead(200, { 'Content-Type': 'text/css' })
+        res.end(result.css)
+      })
   } else if (path === '/lots-o-docs.json') {
     return request('https://gist.githubusercontent.com/nathanbowser/7eda0518120d7bac6847/raw/c7de51421ef571232f2a2acb690edc2ba8261fac/gistfile1.json').pipe(res)
   } else if (path === '/documents.json') {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "A Scoreboard tree rendered from a stream using d3",
   "main": "index.js",
   "dependencies": {
+    "bourbon": "^4.2.3",
     "d3": "^3.5.2",
     "escape-string-regexp": "^1.0.3",
-    "lesshat": "^3.0.2"
+    "node-bourbon": "^4.2.3",
+    "node-sass": "^3.2.0"
   },
   "devDependencies": {
     "JSONStream": "^0.10.0",
     "browserify": "^3.46.0",
-    "less": "^1.7.0",
     "lodash": "^2.4.1",
     "request": "^2.36.0",
     "tape": "^3.5.0",
@@ -20,9 +21,11 @@
   },
   "scripts": {
     "bundle": "browserify -r ./index.js:tree -r http -r JSONStream > example/bundle.js -d",
-    "watch": "watchify -r ./index.js:tree -r http -r JSONStream -o example/bundle.js -d",
+    "css": "mkdir dist  &> /dev/null && node-sass --include-path node_modules/bourbon/app/assets/stylesheets tree.scss > dist/tree.css",
+    "postinstall": "npm run css",
     "start": "node example/server.js",
-    "test": "testling && killall phantomjs &> /dev/null"
+    "test": "testling && killall phantomjs &> /dev/null",
+    "watch": "watchify -r ./index.js:tree -r http -r JSONStream -o example/bundle.js -d"
   },
   "repository": {
     "type": "git",

--- a/tree.scss
+++ b/tree.scss
@@ -1,8 +1,8 @@
-@import "node_modules/lesshat/build/lesshat-prefixed";
+@import "bourbon";
 
-@transition: 300ms ease-out;
+$transition: 300ms ease-out;
 
-.base-node() {
+@mixin base-node() {
   list-style: none;
   position: absolute;
   width: 100%;
@@ -13,7 +13,7 @@
 
   .node-contents {
     margin: 6px;
-    .lh-transition(transform @transition, opacity @transition);
+    @include transition(transform $transition, opacity $transition);
     margin-left: -6px;
     text-align: left;
     white-space: nowrap;
@@ -44,10 +44,10 @@
   height: 100%;
 
   .traveling-node {
-    .base-node;
+    @include base-node;
 
     background-color: #D9E2E8;
-    width: calc(~"100% + 15px");
+    width: calc(#{"100% + 15px"});
     cursor: pointer;
 
     &.forest-traveler {
@@ -85,16 +85,16 @@
     width: 100%;
     height: 100%;
 
-    .lh-user-select(none);
+    @include user-select(none);
 
     &.notransition {
       ul {
         li.node {
-          .lh-transition(none) !important;
+           @include transition(none !important);
           .node-contents {
-            .lh-transition(none) !important;
+            @include transition(none !important);
             .toggler {
-              .lh-transition(none) !important;
+              @include transition(none !important);
             }
           }
         }
@@ -115,7 +115,7 @@
     &:hover {
       // Don't show it for the root node on normal trees
       li.node:not(.root):not(.search-result) {
-        .toggler { .lh-opacity(1); }
+        .toggler { opacity: 1; }
       }
     }
 
@@ -123,11 +123,11 @@
       list-style-type: none;
       padding: 0px;
       margin: 0px;
-      .lh-translateX(0); // Specify 0 transform, otherwise we get overflow on nodes
+      @include transform(translateX(0)); // Specify 0 transform, otherwise we get overflow on nodes
 
       li.node {
-        .base-node;
-        .lh-transition(transform @transition, opacity @transition, height @transition);
+        @include base-node;
+        @include transition(transform $transition, opacity $transition, height $transition);
 
         &.transitioning-node {
           pointer-events: none;
@@ -140,10 +140,10 @@
             vertical-align: middle;
             width: 14px;
             height: 14px;
-            .lh-opacity(0);
-            .lh-transform(rotate(0deg));
-            .lh-transform-origin(7px 7px);
-            .lh-transition(all @transition);
+            opacity: 0;
+            @include transform(rotate(0deg));
+            @include transform-origin(7px 7px);
+            @include transition(all $transition);
 
             svg {
               position: absolute;
@@ -152,7 +152,7 @@
               fill: #818b8f;
             }
 
-            &.expanded { .lh-transform(rotate(90deg)); }
+            &.expanded { @include transform(rotate(90deg)); }
             &.leaf { visibility: hidden !important; }
           }
 
@@ -181,7 +181,7 @@
           height: 100%;
           top: 0;
           right: 0;
-          .lh-background-image(linear-gradient(to right, rgba(57,60,64,0) 0%, #393c40 90%));
+          @include background-image(linear-gradient(to right, rgba(57,60,64,0) 0%, #393c40 90%));
 
           &:after {
             content: "";
@@ -194,7 +194,7 @@
           }
 
           &.indicator {
-            .lh-background-image(linear-gradient(to right, rgba(57,60,64,0) 0%, #393c40 50%));
+            @include background-image(linear-gradient(to right, rgba(57,60,64,0) 0%, #393c40 50%));
           }
         }
 
@@ -226,10 +226,10 @@
 
           .label { color: #E1E8EB; }
           .label-mask {
-            .lh-background-image(linear-gradient(to right, rgba(45,49,53,0) 0%, #2d3135 90%));
+            @include background-image(linear-gradient(to right, rgba(45,49,53,0) 0%, #2d3135 90%));
 
             &.indicator {
-              .lh-background-image(linear-gradient(to right, rgba(45,49,53,0) 0%, #2d3135 50%));
+              @include background-image(linear-gradient(to right, rgba(45,49,53,0) 0%, #2d3135 50%));
             }
           }
         }
@@ -243,7 +243,7 @@
             background-color: inherit;
           }
           .toggler {
-            .lh-opacity(0) !important; // Never show the toggler when the user is dragging
+             opacity: 0 !important; // Never show the toggler when the user is dragging
           }
         }
       }


### PR DESCRIPTION
Adds a postinstall script to generate tree.css which can be included as
a dependency.

Check this out:

```
$ npm install git+ssh://git@github.com:spiderstrategies/scoreboard-tree.git#sass
|
> node-sass@3.2.0 install /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree/node_modules/node-sass
> node scripts/install.js

Binary downloaded and installed at /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree/node_modules/node-sass/vendor/darwin-x64-11/binding.node

> node-sass@3.2.0 postinstall /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree/node_modules/node-sass
> node scripts/build.js

` /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree/node_modules/node-sass/vendor/darwin-x64-11/binding.node ` exists. 
 testing binary.
Binary is fine; exiting.

> scoreboard-tree@0.0.2 postinstall /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree
> npm run css


> scoreboard-tree@0.0.2 css /Users/koopa/dev/scoreboard/sb3-canvas-playground/node_modules/scoreboard-tree
> node-sass --include-path node_modules/bourbon/app/assets/stylesheets tree.scss > tree.css

scoreboard-tree@0.0.2 node_modules/scoreboard-tree
├── escape-string-regexp@1.0.3
├── node-bourbon@4.2.3
├── bourbon@4.2.3
└── node-sass@3.2.0 (get-stdin@4.0.1, async-foreach@0.1.3, nan@1.8.4, mkdirp@0.5.1, chalk@1.1.0, npmconf@2.1.2, meow@3.3.0, glob@5.0.14, gaze@0.5.1, request@2.60.0, sass-graph@2.0.0, pangyp@2.2.1)
```

So now you just include the scoreboard-tree/tree.css as a dependency, and it's generated when the package is installed? Thoughts @jerryorr, @scottoreilly, and @mattsgarlata 
