### PR TITLE
handle no-op selection quickly

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,6 +421,10 @@ Tree.prototype.copy = function (node, to, transformer) {
  *    - animate: Disable animations
  */
 Tree.prototype.select = function (id, opt) {
+  // handle no-op selection quickly without messing with the dom
+  if (this._selected && this._selected.id == id) {
+    return
+  }
   opt = opt || {}
   if (typeof opt.toggleOnSelect === 'undefined') {
     opt.toggleOnSelect = this.options.toggleOnSelect


### PR DESCRIPTION
I was doing some performance tuning on the metrics report, and noticed there was a significant slowdown when switching between tabs in scoreboard that was attributable to the tree.  When SB was requesting a node be selected and it already was, the tree was doing a lot of work that it didn't need to.  For testing I was working with a giant tree, so that's why we hadn't seen the issue before.
