### PR TITLE
Only draw nodes that are within the scrolling viewport.

### DIFF
--- a/lib/enter.js
+++ b/lib/enter.js
@@ -2,6 +2,48 @@ var partialRight = require('./partial-right')
   , d3 = require('d3')
   , DnD = require('./dnd')
 
+var contents = function (selection, tree, transformContentsStyle, cssClasses) {
+  // Add the node contents
+  function field (id, field) {
+    var n = tree.nodes[id]
+    return n ? n[field] : ''
+  }
+  var contents = selection.append('div')
+                            .attr('class', 'node-contents')
+                            .attr('style', transformContentsStyle)
+
+  // Add the toggler
+  contents.append('div')
+          .attr('class', function (d) {
+            return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
+          })
+          .on('click', tree._onToggle.bind(tree))
+          .append('svg')
+                 .append('use')
+                   .attr('xlink:href', '#icon-collapsed')
+
+  contents.append('svg')
+          .attr('class', function (d) {
+            return 'icon ' + field(d.id, tree.options.accessors.color)
+          })
+          .append('use')
+          .attr('xlink:href', function (d) {
+            return '#icon-' + field(d.id, tree.options.accessors.icon)
+          })
+
+  contents.append('div')
+          .attr('class', 'label')
+          .text(function (d) {
+            return field(d.id, tree.options.accessors.label)
+          })
+
+  // Now the label mask
+  selection.append('div')
+          .attr('class', function (d) {
+            return (tree.options.indicator ? 'label-mask indicator ' : 'label-mask ') + field(d.id, tree.options.accessors.color)
+          })
+}
+
 module.exports = function (tree) {
   var dnd = new DnD(tree)
     , listener = d3.behavior.drag()
@@ -21,7 +63,9 @@ module.exports = function (tree) {
     if (!cssClasses && !transformContentsStyle) {
       transformContentsStyle = defaultContent
     }
-    var transitions = tree.el.select('.tree').classed('transitions')
+
+    var node = tree.el.select('.tree').node()
+      , transitions = tree.el.select('.tree').classed('transitions')
       , enter = selection.enter()
                          .append('li')
                            .attr('class', 'node ' + (cssClasses || '') + (transitions ? ' transitioning-node' : ''))
@@ -32,48 +76,24 @@ module.exports = function (tree) {
                            .call(listener)
                            .style(tree.prefix + 'transform', transformNodeStyle)
 
+    // Just render the nodes that are visible in the tree at first
+    enter.filter(function (d) {
+           if (transitions) { return true }
+           return d._y >= node.scrollTop && d._y <= node.offsetHeight + node.scrollTop
+         })
+         .call(contents, tree, transformContentsStyle)
+
     if (transitions) {
       enter.style('opacity', 1e-6)
+    } else {
+      process.nextTick(function () {
+        // Now that visible nodes are in the dom, add the contents for remaining nodes
+        enter.filter(function (d) {
+               return !this.children.length
+             })
+             .call(contents, tree, transformContentsStyle)
+      })
     }
-
-    // Add the node contents
-    var contents = enter.append('div')
-                          .attr('class', 'node-contents')
-                          .attr('style', transformContentsStyle)
-
-    // Add the toggler
-    var toggler = contents.append('div')
-                          .attr('class', function (d) {
-                            return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
-                          })
-                          .on('click', tree._onToggle.bind(tree))
-    // icon to represent the node type
-    contents.append('svg')
-            .attr('class', function (d) {
-              return 'icon ' + tree.nodes[d.id][tree.options.accessors.color]
-            })
-            .append('use')
-            .attr('xlink:href', function (d) {
-              return '#icon-' + tree.nodes[d.id][tree.options.accessors.icon]
-            })
-
-    contents.append('div')
-            .attr('class', 'label')
-            .text(function (d) {
-              return tree.nodes[d.id][tree.options.accessors.label]
-            })
-
-    // Now the label mask
-    enter.append('div')
-            .attr('class', function (d) {
-              return (tree.options.indicator ? 'label-mask indicator ' : 'label-mask ') + tree.nodes[d.id][tree.options.accessors.color]
-            })
-
-    process.nextTick(function () {
-      toggler.append('svg')
-             .append('use')
-               .attr('xlink:href', '#icon-collapsed')
-    })
 
     if (transitions) {
       tree._forceRedraw() // Force a redraw so we see the updates transitioning

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -93,25 +93,28 @@ test('drag moves traveler', function (t) {
     var node = tree.node[0][3]
       , data = tree._layout[1004]
     tree.editable()
-    dnd.start.apply(node, [data, 3])
-    t.ok(dnd.timeout, 'timeout was set')
-    d3.event.y = data._y
-    dnd.drag.apply(node, [data, 3])
-    t.equal(tree.el.select('.traveling-node').datum()._y, data._y - tree.options.height / 2, 'traveler _y starts centered on the the src')
-    d3.event.y = data._y + 200// new y location
-    dnd.drag.apply(node, [data, 3])
-    t.ok(tree.el.select('.traveling-node').datum()._y > data._y, 'traveler _y moved down')
-    t.equal(tree.el.select('.traveling-node').datum().i, 8, 'moved down nodes')
-    t.equal(tree.el.select('.traveling-node').attr('style'), tree.prefix + 'transform: translate(0px, 290px); opacity: 1;', 'transform changed')
-    t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(60px,0px)', '60px y indentation')
-    d3.event.y = 290 // move the node up a little
-    dnd.drag.apply(node, [data, 3])
+    process.nextTick(function () {
+      dnd.start.apply(node, [data, 3])
+      t.ok(dnd.timeout, 'timeout was set')
+      d3.event.y = data._y
+      dnd.drag.apply(node, [data, 3])
+      t.equal(tree.el.select('.traveling-node').datum()._y, data._y - tree.options.height / 2, 'traveler _y starts centered on the the src')
+      d3.event.y = data._y + 200// new y location
+      dnd.drag.apply(node, [data, 3])
+      process.nextTick(function () {})
+      t.ok(tree.el.select('.traveling-node').datum()._y > data._y, 'traveler _y moved down')
+      t.equal(tree.el.select('.traveling-node').datum().i, 8, 'moved down nodes')
+      t.equal(tree.el.select('.traveling-node').attr('style'), tree.prefix + 'transform: translate(0px, 290px); opacity: 1;', 'transform changed')
+      t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(60px,0px)', '60px y indentation')
+      d3.event.y = 290 // move the node up a little
+      dnd.drag.apply(node, [data, 3])
 
-    // now it should be embedded
-    t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(80px,0px)', '80px y indentation')
-    dnd.end.apply(node, [data, 3])
-    tree.remove()
-    t.end()
+      // now it should be embedded
+      t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(80px,0px)', '80px y indentation')
+      dnd.end.apply(node, [data, 3])
+      tree.remove()
+      t.end()
+    })
   })
 })
 

--- a/test/forest-tree-test.js
+++ b/test/forest-tree-test.js
@@ -191,33 +191,34 @@ test('dnd allows a node to become a new root', function (t) {
     , dnd = new Dnd(tree)
 
   s.on('end', function () {
-    var node = tree.node[0][2]
-      , data = tree._layout[1003]
-    d3.event = new Event
-    d3.event.sourceEvent = new Event
+    process.nextTick(function () {
+      var node = tree.node[0][2]
+        , data = tree._layout[1003]
+      d3.event = new Event
+      d3.event.sourceEvent = new Event
 
-    t.equal(tree.root.length, 2, 'two root nodes to start')
+      t.equal(tree.root.length, 2, 'two root nodes to start')
 
-    tree.editable()
-    dnd.start.apply(node, [data, 2])
-    d3.event.y = 5
-    dnd.drag.apply(node, [data, 2])
-    t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(0px,0px)', '0px y indentation')
+      tree.editable()
+      dnd.start.apply(node, [data, 2])
+      d3.event.y = 5
+      dnd.drag.apply(node, [data, 2])
+      t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(0px,0px)', '0px y indentation')
 
-    tree.on('move', function (n, newParent, previousParent, newIndex, previousIndex) {
-      t.equal(n.id, 1003, 'moved node id matches 1003')
-      t.ok(!newParent, 'no new parent')
-      t.equal(previousParent.id, 1002, 'preview parent is 1002')
-      t.equal(newIndex, 0, 'new index 0')
-      t.equal(previousIndex, 0, 'prev index 0')
+      tree.on('move', function (n, newParent, previousParent, newIndex, previousIndex) {
+        t.equal(n.id, 1003, 'moved node id matches 1003')
+        t.ok(!newParent, 'no new parent')
+        t.equal(previousParent.id, 1002, 'preview parent is 1002')
+        t.equal(newIndex, 0, 'new index 0')
+        t.equal(previousIndex, 0, 'prev index 0')
 
-      t.equal(tree.root.length, 3, 'three root nodes')
-      t.deepEqual(tree.root[0], data, 'new first root is the node moved')
+        t.equal(tree.root.length, 3, 'three root nodes')
+        t.deepEqual(tree.root[0], data, 'new first root is the node moved')
 
-      tree.remove()
-      t.end()
+        tree.remove()
+        t.end()
+      })
+      dnd.end.apply(node, [data, 2])
     })
-    dnd.end.apply(node, [data, 2])
-
   })
 })

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -102,7 +102,7 @@ test('selects a node', function (t) {
   t.ok(tree._layout[1003].children, 'selected node is expanded')
 
   tree.collapseAll()
-  setTimeout(function () {
+  process.nextTick(function () {
     // wait for the tree to be collapsed, then select a deep leaf.
     tree.select(1004)
     // Make sure all ancestors of the selected node are also expanded.
@@ -113,7 +113,7 @@ test('selects a node', function (t) {
     t.ok(leaf.parent.parent.parent.children, 'Root has children')
     tree.el.remove()
     t.end()
-  }, 400)
+  })
 })
 
 test('select a node adds transitions by default', function (t) {
@@ -236,10 +236,11 @@ test('getSelectedEl returns the selected node\'s dom element', function (t) {
 
   var data = tree.selected()
     , el = tree.selectedEl()
-
-  t.equal(data.label, el.querySelector('.label').innerHTML, 'selected dom node label is correct')
-  tree.el.remove()
-  t.end()
+  process.nextTick(function () {
+    t.equal(data.label, el.querySelector('.label').innerHTML, 'selected dom node label is correct')
+    tree.el.remove()
+    t.end()
+  })
 })
 
 test('editable', function (t) {
@@ -574,21 +575,7 @@ test('toggle a specific node', function (t) {
   t.ok(tree._layout[1002].children, 'node should have children')
   t.ok(!tree._layout[1002]._children, 'node should not have hidden children')
   t.equal(el.querySelectorAll('.tree ul li').length, 8, 'root + children + first child expanded')
-  return t.end()
-  process.nextTick(function () {
-    t.equal(el.querySelector('.tree ul li:nth-child(4) .label').innerHTML, 'O1', 'P2 first child is visible')
-    // Now toggle again
-    tree.toggle(tree.get(1002))
-    t.ok(!tree._layout[1002].children, 'node should not have children')
-    t.ok(tree._layout[1002]._children, 'node should have hidden children')
-
-    // pause since exit has a 300 duration
-    setTimeout(function () {
-      t.equal(el.querySelectorAll('.tree ul li').length, 3, 'root + children visible')
-      tree.el.remove()
-      t.end()
-    }, 400)
-  })
+ t.end()
 })
 
 test('click toggler listener', function (t) {
@@ -596,14 +583,14 @@ test('click toggler listener', function (t) {
     , tree = new Tree({stream: s}, {})
 
   s.on('end', function () {
-    process.nextTick(function () {
+    setTimeout(function () {
       var node = tree._layout[1002]
       t.ok(!node.children, 'first child has hidden children')
       tree.node[0][1].querySelector('.toggler').click()
       t.ok(node.children, 'first child has children after click event')
       tree.remove()
       t.end()
-    })
+    }, 10)
   })
   tree.render()
 })


### PR DESCRIPTION
On nextTick, once things are in the dom, we draw the other nodes. This
way things look faster than they really are from the user's perspective.
