### PR TITLE
Assigns the new node's parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -604,6 +604,7 @@ Tree.prototype.add = function (d, parent, idx) {
     return
   }
 
+  _d.parent = parent
   this.nodes[d.id] = d
   this._layout[_d.id] = _d
 

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -396,6 +396,24 @@ test('prevents add for a node w/ that id', function (t) {
   tree.render()
 })
 
+test('adds a node to a parent without children', function (t) {
+  var tree = new Tree({stream: stream()}).render()
+    , el = tree.el.node()
+
+  var d = tree.add({
+    id: 1001010101,
+    label: 'Newest node',
+    color: 'green',
+    nodeType: 'metric'
+  }, 1070)
+
+  process.nextTick(function () {
+    t.deepEqual(tree._layout[1001010101].parent, tree._layout[1070], 'new node\'s parent is correct')
+    t.equal(tree.nodes[1001010101], d, 'node was added to nodes')
+    t.end()
+  })
+})
+
 test('adds a node to a parent', function (t) {
   var tree = new Tree({stream: stream()}).render()
     , el = tree.el.node()


### PR DESCRIPTION
Previously if the node wasn't visible, it wouldn't assign the parent
object for the node when we rebind data. That would prevent other
operations in the tree from working, such as selecting a node and
expanding its ancestors, since the node being selected didn't have a
parent.

Fixes #197
