### PR TITLE
Uses the new sassy importer to search for imports in all of

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "bourbon": "^4.2.3",
     "d3": "^3.5.2",
     "escape-string-regexp": "^1.0.3",
-    "node-sass": "^3.2.0"
+    "node-sass": "^3.2.0",
+    "node-sassy-importer": "^1.0.1"
   },
   "devDependencies": {
     "JSONStream": "^0.10.0",
@@ -20,7 +21,7 @@
   },
   "scripts": {
     "bundle": "browserify -r ./index.js:tree -r http -r JSONStream > example/bundle.js -d",
-    "css": "if not exist dist mkdir dist &&  node-sass --include-path node_modules/bourbon/app/assets/stylesheets tree.scss > dist/tree.css",
+    "css": "if not exist dist mkdir dist && sass-import tree.scss > dist/tree.css",
     "postinstall": "npm run css",
     "start": "node example/server.js",
     "test": "testling && killall phantomjs &> /dev/null",


### PR DESCRIPTION
node_modules, so we don't have to worry about relative path breakage.

@dankolz Check this out. Will this work?
