### PR TITLE
DND drag nodes are always animated.

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -221,7 +221,7 @@ Dnd.prototype._drag = function (d, i, node) {
       self.tree._transitionWrap(function () {
         self.tree._rebind()
                  .call(self.updater)
-      })()
+      }, true)()
     }
     return d
   })


### PR DESCRIPTION
Fixes #216
