### PR TITLE
Empty search calls shouldn't toggle a tree that isn't displaying search

### DIFF
--- a/index.js
+++ b/index.js
@@ -838,7 +838,9 @@ Tree.prototype.removeNode = function (obj) {
 
 Tree.prototype.search = function (term) {
   if (term == null) {
-    return this.select((this._selected && this._selected.id) || (this.options.forest ? this.root[0].id : this.root.id), {force: true})
+    return this.select((this._selected && this._selected.id) || (this.options.forest ? this.root[0].id : this.root.id), {
+      force: this.node.classed('search-result')
+    })
   }
 
   var re = new RegExp(regexEscape(term), 'ig')

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -4,6 +4,24 @@ var test = require('tape').test
   , stream = require('./tree-stream')
   , Transform = require('stream').Transform
 
+test('search call is noop if not displaying search results', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s}).render()
+    , el = tree.el.node()
+
+  s.on('end', function () {
+    tree.select(1058)
+    t.equal(tree.node.size(), 8, '8 initial nodes')
+    tree.search()
+    t.equal(tree.node.size(), 8, '8 nodes displayed after search for null')
+    tree.search()
+    t.equal(tree.node.size(), 8, '8 nodes displayed because it should not toggle')
+
+    tree.remove()
+    t.end()
+  })
+})
+
 test('search', function (t) {
   var s = stream()
     , tree = new Tree({stream: s}).render()


### PR DESCRIPTION
results.

Fixes #219
