### PR TITLE
Improves dnd _move logic.

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -1,7 +1,10 @@
 var d3 = require('d3')
   , update = require('./update')
   , startMs = 300
-  , threshold = 10
+
+var clamp = function (value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
 
 var Dnd = function (tree) {
   var self = this
@@ -42,7 +45,6 @@ Dnd.prototype._createTraveler = function (d, i, node) {
                       _source: d,
                       _initialParent: d.parent && d.parent.id,
                       _initialIndex: this._getIndex(d),
-                      i: i,
                       embedded: false
                     })
   this.tree.el.node().appendChild(this.traveler.node())
@@ -156,68 +158,97 @@ Dnd.prototype._autoscroll = function (d, tree, y) {
   }
 }
 
-Dnd.prototype._move = function (y, d) {
-  var self = this
-  this.traveler.datum(function (d) {
-    // Determine the upper and lower bounds for the traveling node
-    var treeNode = self.tree.el.select('.tree').node()
-      , lowerBound = treeNode.offsetHeight + treeNode.scrollTop - self.tree.options.height
-      , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2
+/*
+ * Returns the dropzone for the traveling node.
+ * The incoming variable denotes the top of the traveling node.
+ *
+ */
+Dnd.prototype._getDropzone = function (_y) {
+  var top = _y + (this.tree.options.height / 2) // Top of the traveling node
+    , last = d3.select(this.tree.node[0][this.tree.node.size() - 1]).datum()._y
+    , threshold = Math.min(top - (top % this.tree.options.height), last)
 
-    d._y = Math.min(Math.max(y - (self.tree.options.height / 2), upperBound), lowerBound)
-    var prev = d.i
-    // Set this index to where it would be in the tree
-    d.i = Math.min(~~((d._y + (self.tree.options.height / 2)) / self.tree.options.height), self.tree.node.size() - 1) // can't be greater than the max index
+  return this.tree.node.filter(function (d) {
+                          return d._y >= threshold
+                       })[0][0] // Return the first
+}
 
-    var source = d._source
-      , ci = d.i - prev // change in i
-      , before = null
-      , dropzone = null
-      , embed = false
+/*
+ * Returns the node before the dropzone
+ */
+Dnd.prototype._getBefore = function (dropzone) {
+  var idx = this.tree.node[0].indexOf(dropzone)
+    , before = this.tree.node[0][idx - 1]
 
-    if (self.tree.options.forest && d.i === 0) {
-      // new top root
-      before = {} // mock this thing
-      dropzone = d3.select(self.tree.node[0][Math.max(d.i)]).datum()
-    } else {
-      before = d3.select(self.tree.node[0][Math.max(d.i - 1, 0)]).datum()
-      dropzone = d3.select(self.tree.node[0][Math.max(d.i, 0)]).datum()
-    }
+  if (before) {
+    return d3.select(before).datum()
+  } else {
+    return null
+  }
+}
 
-    var diff = d._y % (before._y + (self.tree.options.height / 2))
-    if (diff && diff <= threshold) {
+/*
+ * Determines if the node should be embedded on the node that's before the dropzone
+ */
+Dnd.prototype._isEmbedded = function (d, y, before) {
+  if (!before && this.tree.options.forest) {
+    // It must be a root node for a forest, which means it's not embedded
+    return false
+  }
+
+  var embed = false
+    , threshold = 10
+    , diff = y % (before._y + (this.tree.options.height / 2))
+
+  if (diff && diff <= threshold) {
+    embed = true
+  }
+
+  if (before.children) {
+    if (before.children.length > 1) {
       embed = true
     }
-
-    if (before.children) {
-      if (before.children.length > 1) {
-        embed = true
-      }
-      if (before.children.length == 1 && before.children[0] != source) {
-        embed = true
-      }
+    if (before.children.length == 1 && before.children[0] != d) {
+      embed = true
     }
+  }
+  return embed
+}
 
-    if (ci || d.embedded != embed) {
-      // This means we're modifying the data in the tree. The `ci` (change in i) variable changed
-      // or the node's embedded  property has now changed
+Dnd.prototype._move = function (y, d) {
+  var self = this
+    , treeNode = this.tree.el.select('.tree').node()
+    , lowerBound = treeNode.offsetHeight + treeNode.scrollTop - self.tree.options.height
+    , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2
+    , _y = clamp(y - (self.tree.options.height / 2), upperBound, lowerBound) // The travelers y position for the middle of the node
+    , prev = d._y // The previous position of the traveler
+    , _dropzone = self._getDropzone(_y)
+    , dropzone = d3.select(_dropzone).datum()
+    , before = this._getBefore(_dropzone)
+    , embed = self._isEmbedded(d, _y, before)
+
+  this.traveler.datum(function (d) {
+    d._y = _y
+
+    if (d._y !== prev || d.embedded != embed) {
+      // This means we're modifying the data in the tree or the node's embedded property has now changed
 
       // Remove the node from its current location
-      self._remove(source)
+      self._remove(d._source)
 
       var newParent = embed ? before : dropzone.parent
         , children = null
 
-      if (dropzone == source && !embed) {
-        newParent = before.parent
+      if (dropzone == d._source && !embed) {
+        newParent = before && before.parent
       }
 
-      if (newParent == source) {
+      if (newParent == d._source) {
         newParent = dropzone
       }
 
       if (!newParent) {
-        source.parent = null
+        d._source.parent = null
         children = self.tree.root
       } else if (newParent.collapsed && newParent._allChildren) {
         // Dropping onto a collapsed node with children.
@@ -230,7 +261,7 @@ Dnd.prototype._move = function (y, d) {
       }
 
       var idx = null
-      if (!embed && d.i == self.tree.node.size() -1) {
+      if (!embed && dropzone === d3.select(self.tree.node[0][self.tree.node.size() - 1]).datum()) {
         // This means the node is being inserted at the very bottom, set it to the end of the parent's children
         idx = children.length
       } else {
@@ -243,7 +274,7 @@ Dnd.prototype._move = function (y, d) {
         idx = children.indexOf(before) + 1
       }
 
-      children.splice(idx, 0, source)
+      children.splice(idx, 0, d._source)
       d.embedded = embed
 
       self.tree._transitionWrap(function () {

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -104,7 +104,6 @@ test('creates a traveler after timeout', function (t) {
       var travelerData = traveler.datum()
       t.equal(travelerData._initialParent, 1003, 'stores initial parent on the traveler')
       t.deepEqual(travelerData._source, tree._layout[1004], 'stores source node on the travler')
-      t.deepEqual(travelerData.i, 3, 'sets i')
       t.deepEqual(travelerData.embedded, false, 'embedded is false by default')
       dnd.end.apply(tree.node[0][3], [tree._layout[1004], 3])
       tree.remove()
@@ -145,7 +144,6 @@ test('drag moves traveler', function (t) {
       d3.event.y = data._y + 200// new y location
       dnd.drag.apply(node, [data, 3])
       t.ok(tree.el.select('.traveling-node').datum()._y > data._y, 'traveler _y moved down')
-      t.equal(tree.el.select('.traveling-node').datum().i, 8, 'moved down nodes')
       var _translate = /translate\((.*)\)/.exec(tree.el.select('.traveling-node').attr('style'))[0]
       t.equal(_translate, 'translate(0px, 290px)', 'transform changed')
       t.equal(tree.el.select('.traveling-node').select('.node-contents').attr('style'), tree.prefix + 'transform:translate(60px,0px)', '60px y indentation')


### PR DESCRIPTION
This ditches an approach i used previously by figuring the index of the
traveling node within tree.node. This works if all the elements are on
the page, but fails if we want to hide some nodes.

I tried multi approaches for figuring out where we're dropping the node.
I tried to ask the dom which element is at a location. This actually
works really well. I would hide the traveling node, get the dom element
underneath it, which is a li.node, and then show the traveling node
again. However this fails w/ transitions if the user is moving their
mouse quickly, so we have do things with math + data.

Generally, this cleans up a lot of the move code, which should help
figure out a solution to #174 as well.
