### PR TITLE
Rewrites (read: cleanups) dnd.

### DIFF
--- a/index.js
+++ b/index.js
@@ -870,8 +870,12 @@ Tree.prototype._removeFromParent = function (node) {
       parent._allChildren.splice(i, 1)
     }
   } else if (this.options.forest) {
-    this.root.splice(this.root.indexOf(node), 1)
+    var i = this.root.indexOf(node)
+    if (i !== -1) {
+      this.root.splice(i, 1)
+    }
   }
+  node.parent = null
 
   return this
 }

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -159,13 +159,13 @@ Dnd.prototype._autoscroll = function (d, tree, y) {
 }
 
 /*
- * Returns the dropzone for the traveling node.
- * The incoming variable denotes the top of the traveling node.
- *
+ * Returns the target node if the user lifts their mouse. It's pretty confusing
+ * but it's more of the target node placeholder. It doesn't take into account whether or
+ * not we're embedding the node
  */
-Dnd.prototype._getDropzone = function (_y) {
+Dnd.prototype._getTarget = function (_y) {
   var top = _y + (this.tree.options.height / 2) // Top of the traveling node
-    , last = d3.select(this.tree.node[0][this.tree.node.size() - 1]).datum()._y
+    , last = d3.select(this.tree.node[0][this.tree.node.size() - 1]).datum()._y // last node currently displayed in the tree
     , threshold = Math.min(top - (top % this.tree.options.height), last)
 
   return this.tree.node.filter(function (d) {
@@ -173,46 +173,96 @@ Dnd.prototype._getDropzone = function (_y) {
                        })[0][0] // Return the first
 }
 
-/*
- * Returns the node before the dropzone
- */
-Dnd.prototype._getBefore = function (dropzone) {
-  var idx = this.tree.node[0].indexOf(dropzone)
-    , before = this.tree.node[0][idx - 1]
+Dnd.prototype._isEmbedded = function (d, target, _y) {
+  var threshold = target._y - 8
+    , embed = threshold >= _y
+    , p = target.parent
+    , c = p && p.children || []
 
-  if (before) {
-    return d3.select(before).datum()
-  } else {
-    return null
-  }
-}
-
-/*
- * Determines if the node should be embedded on the node that's before the dropzone
- */
-Dnd.prototype._isEmbedded = function (d, y, before) {
-  if (!before && this.tree.options.forest) {
-    // It must be a root node for a forest, which means it's not embedded
-    return false
-  }
-
-  var embed = false
-    , threshold = 10
-    , diff = y % (before._y + (this.tree.options.height / 2))
-
-  if (diff <= threshold) {
+  if (c.length > 1 && c[0] === target) {
+    // There are children, and the target is the first one
     embed = true
   }
 
-  if (before.children) {
-    if (before.children.length > 1) {
-      embed = true
+  if (d !== target && c[0] === target) {
+    // We're moving the node, `d` to the target, the target is the first child, so it must be embedded
+    embed = true
+  }
+
+  return embed
+}
+
+/*
+ * Returns the node in the tree that is visually right before
+ * the target node.
+ */
+Dnd.prototype._previous = function (d, target) {
+  var height = this.tree.options.height
+    , p = this.tree.node.filter(function (d) {
+                          return d._y === target._y - height
+                        })[0][0]
+  if (p) {
+    p = d3.select(p).datum()
+    if (p === d) {
+      // The user is moving down, and the before node matched to the target. That's because
+      // the target hasn't actually been replaced
+      return target
     }
-    if (before.children.length == 1 && before.children[0] != d) {
-      embed = true
+    return p
+  }
+
+  return null
+}
+
+Dnd.prototype._parent = function (d, target, previous, embedded) {
+  if (embedded) {
+    return previous
+  } else {
+    if (d === target) {
+      // Dropping onto ourself and no longer indented, which means
+      // Our new parent is our previous grandparnet
+      return target.parent && target.parent.parent
+    } else {
+      return target.parent
     }
   }
-  return embed
+}
+
+Dnd.prototype._getDropIndex = function (d, children, target, previous, embed) {
+  if (embed) {
+    // If it's embedded, it's always inserted as the first child
+    return 0
+  }
+
+  if (target._y >= d3.select(this.tree.node[0][this.tree.node.size() - 1]).datum()._y) {
+    // The target is the last node, so we're moving it to the bottom
+    return children.length
+  }
+
+  var idx = children.indexOf(target)
+
+  if (idx === -1) {
+    // Then the target isn't part of this children set yet, so use the previous node
+    idx = children.indexOf(previous) + 1
+  }
+
+  return idx
+}
+
+Dnd.prototype._children = function (d, parent, children) {
+  var children = null
+  if (!parent && this.tree.options.forest) {
+    children = this.tree.root
+  } else if (parent.collapsed && parent._allChildren) {
+    // Dropping onto a collapsed node with children.
+    parent._collapsedChildren = parent._allChildren
+    children = parent._allChildren = []
+    parent.collapsed = false
+  } else {
+    children = parent._allChildren || (parent._allChildren = [])
+    parent.collapsed = false
+  }
+  return children
 }
 
 Dnd.prototype._move = function (y, d) {
@@ -221,60 +271,26 @@ Dnd.prototype._move = function (y, d) {
     , lowerBound = treeNode.offsetHeight + treeNode.scrollTop - self.tree.options.height
     , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2
     , _y = clamp(y - (self.tree.options.height / 2), upperBound, lowerBound) // The travelers y position for the middle of the node
-    , prev = d._y // The previous dropzone position
-    , _dropzone = self._getDropzone(_y)
-    , dropzone = d3.select(_dropzone).datum()
-    , before = this._getBefore(_dropzone)
-    , embed = self._isEmbedded(d, _y, before)
+    , target = d3.select(this._getTarget(_y)).datum() // The node that's going to be replaced
+    , embed = this._isEmbedded(d, target, _y)
 
   this.traveler.datum(function (d) {
     d._y = _y
 
-    if (dropzone._y !== prev || d.embedded != embed) {
+    if (d._source != target || d.embedded != embed) {
       // This means we're modifying the data in the tree or the node's embedded property has now changed
+      var previous = self._previous(d._source, target)
+        , newParent = self._parent(d._source, target, previous, embed)
+        , children = self._children(d._source, newParent, children)
+        , idx = self._getDropIndex(d._source, children, target, previous, embed)
 
       // Remove the node from its current location
       self._remove(d._source)
 
-      var newParent = embed ? before : dropzone.parent
-        , children = null
-
-      if (dropzone == d._source && !embed) {
-        newParent = before && before.parent
-      }
-
-      if (newParent == d._source) {
-        newParent = dropzone
-      }
-
-      if (!newParent) {
-        d._source.parent = null
-        children = self.tree.root
-      } else if (newParent.collapsed && newParent._allChildren) {
-        // Dropping onto a collapsed node with children.
-        newParent._collapsedChildren = newParent._allChildren
-        children = newParent._allChildren = []
-        newParent.collapsed = false
-      } else {
-        children = newParent._allChildren || (newParent._allChildren = [])
-        newParent.collapsed = false
-      }
-
-      var idx = null
-      if (!embed && dropzone === d3.select(self.tree.node[0][self.tree.node.size() - 1]).datum()) {
-        // This means the node is being inserted at the very bottom, set it to the end of the parent's children
-        idx = children.length
-      } else {
-        idx = children.length ? children.indexOf(dropzone) : 0
-      }
-
-      // If the dropzone was removed because we're sliding left, then its' not in the tree, so get the index of the before node
-      // and insert the node after that position
-      if (idx == -1) {
-        idx = children.indexOf(before) + 1
-      }
-
+      // Add it to the children
       children.splice(idx, 0, d._source)
+
+      // Store a property on the traveler's data indicating whether it was previously embedded on next move
       d.embedded = embed
 
       self.tree._transitionWrap(function () {


### PR DESCRIPTION
There were quite a few things I found that were wrong.
1. In a foreset tree, if a node was at root, then moved to a child of a
   root sibling, then moved back out to a root node, it still had a parent
   node set from when it was indented. This wasn't immediately obvious in
   the UI, but the data was bad.
2. If you wanted to prevent nodes from being embedded, so default
   `embed` logic wasn't used, it wouldn't correctly figure out the index of
   the new node's location. Basically there was so bad +1 or -1 logic for
   determing an index.
3. General cleanup of dnd so it's not as poorly written. This is much
   more modular and readable, but still somewhat confusing.
