### PR TITLE
Hides horizontal scrolling.

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -91,6 +91,7 @@ $timing-fn: ease-out;
 
   .tree {
     overflow: auto;
+    overflow-x: hidden;
     width: 100%;
     height: 100%;
 


### PR DESCRIPTION
Horizontal scrollbars show up when the vertical scrollbars are added. It
looks like you can fix this with a padding-right on the tree, but the
issue is you don't know the width of the scrollbar based on user's
browser settings.

Fixes #248
