### PR TITLE
Sets embedded to true if target node equals the previous node.

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -178,11 +178,18 @@ Dnd.prototype._getTarget = function (_y) {
                        })[0][0] // Return the first
 }
 
-Dnd.prototype._isEmbedded = function (d, target, _y) {
+Dnd.prototype._isEmbedded = function (d, target, previous, _y) {
   var threshold = target._y - 8
     , embed = threshold >= _y
     , p = target.parent
     , c = p && p.children || []
+
+  if (previous === target) {
+    // When this is called, we're in a virtual state, meaning the previous node hasn't actually moved yet.
+    // If previous is the target, that means the previous will eventually bump up a spot. If that's the case
+    // We want to be embedded since the target will be the first child
+    return true
+  }
 
   if (c.length > 1 && c[0] === target) {
     // There are children, and the target is the first one
@@ -206,6 +213,7 @@ Dnd.prototype._previous = function (d, target) {
     , p = this.tree.node.filter(function (d) {
                           return d._y === target._y - height
                         })[0][0]
+
   if (p) {
     p = d3.select(p).datum()
     if (p === d) {
@@ -277,15 +285,15 @@ Dnd.prototype._move = function (y, d) {
     , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2
     , _y = clamp(y - (self.tree.options.height / 2), upperBound, lowerBound) // The travelers y position for the middle of the node
     , target = d3.select(this._getTarget(_y)).datum() // The node that's going to be replaced
-    , embed = this._isEmbedded(d, target, _y)
+    , previous = self._previous(d, target)
+    , embed = this._isEmbedded(d, target, previous, _y)
 
   this.traveler.datum(function (d) {
     d._y = _y
 
     if (d._source != target || d.embedded != embed) {
       // This means we're modifying the data in the tree or the node's embedded property has now changed
-      var previous = self._previous(d._source, target)
-        , newParent = self._parent(d._source, target, previous, embed)
+      var newParent = self._parent(d._source, target, previous, embed)
         , illegal = false
 
       if (!self.tree.options.droppable(self.tree.nodes[d._source.id], self.tree.nodes[newParent && newParent.id])) {

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -385,3 +385,24 @@ test('marks traveler as illegal if its too deep', function (t) {
     dnd.end.apply(m2, [m2d, 4])
   })
 })
+
+test('multiple moves with embedded traveler if target node equals the previous node', function (t) {
+  // See issue #252
+  before(function (tree, dnd) {
+    tree.editable()
+    dnd.start.apply(tree.node[0][4], [tree._layout[1005], 4])
+
+    var moves = [102,119]
+    moves.forEach(function (pos) {
+      d3.event.y = pos
+      dnd.drag.apply(tree.node[0][4], [tree._layout[1005], 4])
+    })
+
+    // now it should be embedded
+    t.ok(dnd.traveler.datum().embedded, 'the traveler is embedded')
+    t.equal(tree._layout[1005]._y, 108, '1005 is the first child, at 108')
+    tree.remove()
+    document.querySelector('.container').remove()
+    t.end()
+  })
+})


### PR DESCRIPTION
This means the user moved their mouse down to a position where the
traveler is sitting directly on top of the target. When the tree
actually moves, the previous node will be the current target, which
means the node should be the first child .

Fixes #252
