### PR TITLE
Adds the ability to override root node height.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var defaults = function () {
     toggleOnSelect: true, // By default each select will toggle the node if needed. This prevents the toggle
     depth: 20, // indentation depth
     height: 36, // height of each row (repeated in tree.less)
+    rootHeight: 36, // root node height can be overridden
     maxAnimatable: 100, // Disable animations if a node has children greater than this amount
     indicator: false, // show indicator light nodes on the right
     forest: false, // Indicates whether this tree can have multiple root nodes
@@ -67,8 +68,8 @@ var Tree = function (options) {
     }
   }
 
+  this._rootOffset = Math.max(this.options.rootHeight - this.options.height, 0)
   this.prefix = prefix
-
   this.transitionTimeout = 300 // Copied in css
   this.updater = update(this)
   this.enter = enter(this)
@@ -97,6 +98,7 @@ Tree.prototype.render = function () {
 
   this.node = this.el.append('div')
                        .attr('class', 'tree')
+                       .classed('detached-root', !!this._rootOffset)
                        .on('scroll', function () {
                          var scroll = self.el.select('.tree').node().scrollTop
                          if (!self._scrollTop) {
@@ -242,7 +244,7 @@ Tree.prototype._rebind = function () {
     , mapper = function (d, i) {
                  // Store sane copies of x,y that denote our true coords in the tree
                  d._x = d.y
-                 d._y = i * self.options.height
+                 d._y = i * self.options.height + (i > 0 ? self._rootOffset : 0)
                  return d
                }
 
@@ -290,7 +292,7 @@ Tree.prototype._join = function (data) {
                   return inside
                 })
     if (this._tuned) {
-      height = last._y + this.options.height + 'px'
+      height = last._y + this.options.height + this._rootOffset + 'px'
     }
   }
 
@@ -957,7 +959,7 @@ Tree.prototype.search = function (term) {
              }).map(function (key, i) {
                var _d = self._layout[key]
                _d._x = 0
-               _d._y = i * self.options.height
+               _d._y = i * self.options.height + (i > 0 ? self._rootOffset : 0)
                return _d
              })
 

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -169,7 +169,7 @@ Dnd.prototype._autoscroll = function (d, tree, y) {
  * not we're embedding the node
  */
 Dnd.prototype._getTarget = function (_y) {
-  var top = _y + (this.tree.options.height / 2) // Top of the traveling node
+  var top = _y + (this.tree.options.height / 2) - this.tree._rootOffset // Top of the traveling node
     , last = d3.select(this.tree.node[0][this.tree.node.size() - 1]).datum()._y // last node currently displayed in the tree
     , threshold = Math.min(top - (top % this.tree.options.height), last)
 
@@ -209,10 +209,10 @@ Dnd.prototype._isEmbedded = function (d, target, previous, _y) {
  * the target node.
  */
 Dnd.prototype._previous = function (d, target) {
-  var height = this.tree.options.height
-    , p = this.tree.node.filter(function (d) {
-                          return d._y === target._y - height
-                        })[0][0]
+  var p = this.tree.node.filter((function (d) {
+                          // Ignore offsets when determining the previous node based on _y position
+                          return Math.max(d._y - this.tree._rootOffset, 0) === target._y - this.tree.options.height - this.tree._rootOffset
+                        }).bind(this))[0][0]
 
   if (p) {
     p = d3.select(p).datum()
@@ -282,7 +282,7 @@ Dnd.prototype._move = function (y, d) {
   var self = this
     , treeNode = this.tree.el.select('.tree').node()
     , lowerBound = treeNode.offsetHeight + treeNode.scrollTop - self.tree.options.height
-    , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2
+    , upperBound = self.tree.options.forest ? treeNode.scrollTop : treeNode.scrollTop + self.tree.options.height / 2 + this.tree._rootOffset
     , _y = clamp(y - (self.tree.options.height / 2), upperBound, lowerBound) // The travelers y position for the middle of the node
     , target = d3.select(this._getTarget(_y)).datum() // The node that's going to be replaced
     , previous = self._previous(d, target)

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -180,6 +180,25 @@ test('emits stream on errors on tree', function (t) {
   tree.render()
 })
 
+test('adjust root node size', function (t) {
+  var s = stream()
+    , tree = new Tree({
+      stream: s,
+      height: 36,
+      rootHeight: 50
+    }).render()
+
+  s.on('end', function () {
+    t.equal(tree._rootOffset, 14, 'sets root offset')
+    t.ok(tree.el.select('.tree').classed('detached-root'), 'tree has detached-root class')
+    t.equal(tree.node.data()[0]._y, 0, 'root _y is 0')
+    t.equal(tree.node.data()[1]._y, 50, 'first node starts at root height')
+    t.equal(tree.node.data()[2]._y, 86, 'second node includes root offset')
+    tree.remove()
+    t.end()
+  })
+})
+
 test('rebind stores private fields', function (t) {
   var s = stream()
     , tree = new Tree({stream: s}).render()


### PR DESCRIPTION
By default, the root node will have a height equal to the default height
(i.e. 36px). Some trees may want a different (larger) style for the root
node. The tree receives an option `rootHeight` which will be used for
the root node's height. If a tree has a root node height that is larger
than the default node height, the tree has a class of `detached-root`
applied.

Fixes #275
