### PR TITLE
Create traveler node using tree contents generating.

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -40,8 +40,9 @@ Dnd.prototype._createTraveler = function (d, i, node) {
                     .attr('class', 'node traveling-node')
                     .classed('forest-traveler', this.tree.options.forest)
                     .attr('style', placeholder.attr('style'))
-                    .html(placeholder.node().innerHTML)
-                    .datum({
+                    .datum(d) // Set the data to the actual node, so the contents is drawn correctly
+                    .call(this.tree.options.contents, this.tree, false)
+                    .datum({ // Now override it
                       _source: d,
                       _initialParent: d.parent && d.parent.id,
                       _initialIndex: this._getIndex(d),


### PR DESCRIPTION
We can't use innerHTML because safari's svg serializer generates a new
namespace for the icons, which is invalid.

Fixes #282
