### PR TITLE
Prevent search results from being editable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -752,6 +752,10 @@ Tree.prototype.isEditable = function () {
  */
 Tree.prototype.editable = function () {
   var t = this.el.select('.tree')
+  if (t.classed('search-results')) {
+    // search results cannot be in edit mode
+    return
+  }
   t.classed('editable', !t.classed('editable'))
 }
 
@@ -949,6 +953,9 @@ Tree.prototype.removeNode = function (obj) {
 }
 
 Tree.prototype.search = function (term) {
+  if (this.isEditable()) {
+    this.editable()
+  }
   if (term == null) {
     return this.select((this._selected && this._selected.id) || (this.options.forest ? this.root[0].id : this.root.id), {
       force: this.el.select('.tree').classed('search-results')

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -91,6 +91,23 @@ test('search for null clears search', function (t) {
   })
 })
 
+test('search prevents edit mode', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s}).render()
+
+  s.on('end', function () {
+    tree.editable()
+    t.ok(tree.isEditable(), 'tree starts off in edit mode')
+    tree.search('M')
+    t.ok(!tree.isEditable(), 'tree no longer editable')
+    t.ok(tree.el.select('.tree').classed('search-results'), 'tree showing search results')
+    tree.editable()
+    t.ok(!tree.isEditable(), 'tree still not editable')
+    tree.remove()
+    t.end()
+  })
+})
+
 test('ignores rootHeight overrides while showing results', function (t) {
   var s = stream()
     , tree = new Tree({


### PR DESCRIPTION
This prevents search results from showing in an edit state. I asked how things should be displayed on slack. We should wait to merge this until my questions are answered.
