### PR TITLE
Search result selection draws tree in a collapsed state.

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,6 +234,17 @@ Tree.prototype.adjustViewport = function () {
   }
 }
 
+Tree.prototype._clearSearch = function () {
+  // Any rebind of data removes the search-results class
+  this.el.select('.tree')
+           .classed('search-results', false)
+           .on('.search-click', null)
+
+  this._searchResults = null
+
+  return this
+}
+
 /*
  * Rebinds the data to the selection based on the data model in the tree.
  */
@@ -247,10 +258,8 @@ Tree.prototype._rebind = function () {
                  return d
                }
 
-  // Any rebind of data removes the search-results class
-  this.el.select('.tree').classed('search-results', false)
-                         .classed('detached-root', !!this._rootOffset)
-  this._searchResults = null
+  this._clearSearch()
+      .el.select('.tree').classed('detached-root', !!this._rootOffset)
 
   if (this.options.forest) {
     data = this.root.reduce(function (p, subTree) {
@@ -970,6 +979,13 @@ Tree.prototype.search = function (term) {
   this._transitionWrap(function () {
     this.el.select('.tree').classed('search-results', true)
                            .classed('detached-root', false)
+                           .on('click.search-click', function () {
+                              // Capture the click event at the tree level, and collapse all nodes
+                              // before the actual node is selected
+                              self._toggleAll(function (d) {
+                                d.collapsed = true
+                              })
+                           }, true)
     this._searchResults = data
     this._join(data)
         .call(this.enter)

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -91,6 +91,25 @@ test('search for null clears search', function (t) {
   })
 })
 
+test('shows seleceted search result in a collapsed tree', function (t) {
+  var s = stream()
+    , tree = new Tree({ stream: s }).render()
+
+  document.body.appendChild(tree.el.node()) // Add to the dom so the click handlers work
+
+  s.on('end', function () {
+    tree.expandAll()
+    tree.search('M')
+    t.equal(tree.node.size(), 25, '25 nodes visible')
+    t.ok(tree.el.select('.tree').classed('search-results'), 'tree showing search-results')
+    tree.node[0][3].click() // Click on M4
+    t.equal(tree.node.size(), 18, '18 nodes visible') // Not all nodes from previous expandAll
+    t.ok(!tree.el.select('.tree').classed('search-results'), 'tree not showing search-results')
+    tree.remove()
+    t.end()
+  })
+})
+
 test('ignores rootHeight overrides while showing results', function (t) {
   var s = stream()
     , tree = new Tree({


### PR DESCRIPTION
This registers an event handler on the tree, using capture mode, that
will collapse the tree data before the node is selected. When it's
selected it will automatically expand its ancestors, resulting in a tree
that shows just the path to the selected node.

Fixes #292
