### PR TITLE
Adds `selecting` class to a freshly selected node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -656,6 +656,7 @@ Tree.prototype._onSelect = function (d, i, j, opt) {
 
   // tree_.selected stores a previously selected node
   if (this._selected) {
+    var prev = this._selected.id
     // delete the selected field from that node
     delete this._selected.selected
   }
@@ -674,8 +675,18 @@ Tree.prototype._onSelect = function (d, i, j, opt) {
 
   // Adjust selected properties
   this.node.classed('selected', function (d) {
-    return d.selected
-  })
+             return d.selected
+           })
+           .classed('selecting', function (d) {
+             // Mark as `selecting` if it's newly selected
+             return d.selected && d.id !== prev
+           })
+
+  // Trigger a reflow to start any transitions
+  this._forceRedraw()
+
+  // Now the node is no longer `selecting`
+  this.node.classed('selecting', false)
 
   if (!opt.silent) {
     this.emit('select', this.nodes[d.id])

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -159,6 +159,27 @@ test('select a node adds transitions by default', function (t) {
   })
 })
 
+test('marks freshly selected nodes as `selecting`', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s}).render()
+
+  s.on('end', function () {
+    var redraw = tree._forceRedraw
+    tree._forceRedraw = function () {
+      var n = tree.el.selectAll('.tree li.node.selecting')
+      t.equal(n.size(), 1, 'we have a selecting node')
+      redraw.apply(this, arguments)
+    }
+    tree.on('select', function () {
+      t.equal(tree.el.selectAll('.tree li.node.selecting').size(), 0, 'no `selecting` nodes after select event')
+      tree.el.remove()
+      t.end()
+    })
+    t.equal(tree.el.selectAll('.tree li.node.selecting').size(), 0, 'no `selecting` nodes')
+    tree.select(1015)
+  })
+})
+
 test('selected nodes descendants transition from correct location', function (t) {
   var s = stream()
     , tree = new Tree({stream: s}).render()


### PR DESCRIPTION
This can be used to control transitions for nodes that are becoming
selected.

For https://github.com/SpiderStrategies/Scoreboard/issues/5446
