### PR TITLE
Scrolling ios

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=3">
     <link rel="stylesheet" type="text/css" href="tree.css" />
     <link href="//fonts.googleapis.com/css?family=Source+Sans Pro:200italic,200,300italic,300,400italic,400,600italic,600,700italic,700,900italic,900" rel="stylesheet" type="text/css">
     <style>

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -25,6 +25,15 @@ var Dnd = function (tree) {
   this.start = function (d, i) {
     // Prevent dnd if not normal left click
     if (leftClick(d3.event.sourceEvent)) {
+      // When dnd starts, register a touchmove event listener on the
+      // window that will prevent future touch move events from running
+      // This is needed because d3 registers a touchmove on the window that prevents default, which
+      // prevents the tree from scrolling
+      d3.select(window)
+        .on('touchmove.dnd', function () {
+          d3.event.stopPropagation()
+        }, true) // Capture mode so we capture the event first to prevent future touch move events
+
       self._start(d, i, this)
     }
   }
@@ -38,6 +47,9 @@ var Dnd = function (tree) {
 
   this.end = function (d) {
     if (leftClick(d3.event.sourceEvent)) {
+      d3.select(window)
+        .on('touchmove.dnd', null) // Remove our listener hack
+
       self._end(d)
     }
   }
@@ -47,6 +59,13 @@ Dnd.prototype._createTraveler = function (d, i, node) {
   this._travelerTimeout = null
   var placeholder = d3.select(node)
                       .classed('placeholder', true)
+
+  // Now that we know we're in edit mode with a traveling node, disable touch move on the window, which
+  // is what d3 would do if we didn't stopPropagation on dnd start.
+  d3.select(window)
+    .on('touchmove.dnd', function () {
+      d3.event.preventDefault()
+    }, true)
 
   this.traveler = d3.select(document.createElement('div'))
                     .attr('class', 'node traveling-node')

--- a/tree.scss
+++ b/tree.scss
@@ -140,6 +140,8 @@ $timing-fn: ease-out;
   .tree {
     overflow: auto;
     overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+
     width: 100%;
     height: 100%;
 


### PR DESCRIPTION
This is a hack and is pretty annoying, but with d3 v3 our hands are kind of tied.

I ran through options I thought could fix this and am documenting them here for reference. This fix is the least invasive and I don't hate it all that much, so until I do some d3 upgrades, this will get us by.

Other options:

1. Copy and paste a lot of the d3 code that handles drag behavior, and we could override the d3 dragSuppress function. This blows, no way.

2. Upgrade d3 to v4 where we can override it. Meh.

3. Have the tree depend on just the d3 modules it needs/uses. (This is what I'm going to do eventually.)

4. I could overwrite the touchmove.namespace event on the window, too. That’s a hack because we’d need to know internals of how d3 creates its namespaces. I actually went down this path for a bit, but it's super ugly because there drag_id that is increased each time dnd starts. We could keep our own counter so it matches d3, but then if some other module that uses d3 drag behavior has a drag, we'd be out of sync. No bueno.

5. The final thing I thought could work, and does. See code.
