### PR TITLE
Uses `treeNode` to determine `scrollTop`

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -362,8 +362,8 @@ Dnd.prototype._move = function (y, d) {
     return d
   })
   .style(self.tree.prefix + 'transform', function (d) {
-    // Move the traveling node to its new y position, adjusting for scrolling within the container
-    return 'translate(0px,' + (d._y - this.parentNode.firstChild.scrollTop) + 'px)'
+    // Move the traveling node to its new y position, adjusting for scrolling within the tree container
+    return 'translate(0px,' + (d._y - treeNode.scrollTop) + 'px)'
   })
   .classed('illegal', function (d) {
     return d.illegal


### PR DESCRIPTION
... rather than bullshit dom methods that could be wrong if extra nodes
are inserted between the tree and its container.