### PR TITLE
Rewrites update code so it utilizes `contents`.

### DIFF
--- a/lib/contents.js
+++ b/lib/contents.js
@@ -1,3 +1,5 @@
+var d3 = require('d3')
+
 module.exports = function (selection, tree, transitions) {
 
   // Add the node contents
@@ -6,42 +8,84 @@ module.exports = function (selection, tree, transitions) {
     return n ? (n[f] || '') : ''
   }
 
-  var contents = selection.append('div')
-                            .attr('class', 'node-contents')
-                            .attr('style', function (d) {
-                              var x = transitions ? (d.parent ? d.parent._x : 0) : d._x
-                              return tree.prefix + 'transform:' + 'translate(' + x + 'px,0px)'
-                            })
+  selection.each(function (data) {
+    var node = d3.select(this)
+      , contents = node.selectAll('.node-contents')
+                       .data(function (d) {
+                         return [d]
+                       })
+      , enter = contents.enter()
+                        .append('div')
+                          .attr('class', 'node-contents')
+                          .attr('style', function (d) {
+                            var x = transitions ? (d.parent ? d.parent._x : 0) : d._x
+                            return tree.prefix + 'transform:' + 'translate(' + x + 'px,0px)'
+                          })
 
-  // Add the toggler
-  contents.append('div')
-          .attr('class', function (d) {
-            return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
-          })
-          .on('click', tree._onToggle.bind(tree))
-          .append('svg')
-            .append('use')
-              .attr('xlink:href', '#icon-collapsed')
-
-  contents.append('svg')
-          .attr('class', function (d) {
-            return 'icon ' + field(d.id, tree.options.accessors.color) + ' '
-                           + field(d.id, tree.options.accessors.icon) + ' '
-          })
-          .append('use')
-          .attr('xlink:href', function (d) {
-            return '#icon-' + field(d.id, tree.options.accessors.icon)
-          })
-
-  contents.append('div')
-          .attr('class', 'label')
-          .text(function (d) {
-            return field(d.id, tree.options.accessors.label)
-          })
-
-  // Now the label mask
-  selection.append('div')
+    // Add the toggler
+    enter.append('div')
            .attr('class', function (d) {
-             return (tree.options.indicator ? 'label-mask indicator ' : 'label-mask ') + field(d.id, tree.options.accessors.color)
+             return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
            })
+           .on('click', tree._onToggle.bind(tree))
+           .append('svg')
+             .append('use')
+               .attr('xlink:href', '#icon-collapsed')
+
+    enter.append('svg')
+         .attr('class', function (d) {
+           return 'icon ' + field(d.id, tree.options.accessors.color) + ' '
+                          + field(d.id, tree.options.accessors.icon) + ' '
+         })
+         .append('use')
+         .attr('xlink:href', function (d) {
+           return '#icon-' + field(d.id, tree.options.accessors.icon)
+         })
+
+    enter.append('div')
+         .attr('class', 'label')
+         .text(function (d) {
+           return field(d.id, tree.options.accessors.label)
+         })
+
+
+    contents.select('svg.icon')
+            .attr('class', function (d) {
+              return 'icon ' + (tree.nodes[d.id][tree.options.accessors.color] || '') + ' '
+                             + (tree.nodes[d.id][tree.options.accessors.icon] || '')
+            })
+            .select('use')
+            .attr('xlink:href', function (d) {
+              return '#icon-' + tree.nodes[d.id][tree.options.accessors.icon]
+            })
+
+    // change the state of the toggle icon by adjusting its class
+    contents.select('.toggler')
+            .attr('class', function (d) {
+              return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
+            })
+
+    // Perhaps the name changed
+    contents.select('div.label')
+            .text(function (d) {
+              return tree.nodes[d.id][tree.options.accessors.label]
+            })
+
+    // If the tree has indicators, we may need to update the color
+    contents.select('div.indicator')
+            .attr('class', function (d) {
+              return 'label-mask indicator ' + tree.nodes[d.id][tree.options.accessors.color]
+            })
+
+    // Now the label mask
+    node.selectAll('.label-mask')
+        .data(function (d) {
+          return [d]
+        })
+        .enter()
+        .append('div')
+          .attr('class', function (d) {
+            return (tree.options.indicator ? 'label-mask indicator ' : 'label-mask ') + field(d.id, tree.options.accessors.color)
+          })
+  })
 }

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -368,7 +368,7 @@ Dnd.prototype._move = function (y, d) {
   .classed('illegal', function (d) {
     return d.illegal
   })
-  .select('.node-contents')
+  .select(':first-child')
     .attr('style', function (d) {
       // Set the indentation of the traveling node to equal the original node's position, since it
       // will be moved automatically

--- a/lib/enter.js
+++ b/lib/enter.js
@@ -21,7 +21,8 @@ module.exports = function (tree) {
                            .on('click', partialRight(tree._onSelect.bind(tree), tree.options))
                            .call(listener)
                            .style(tree.prefix + 'transform', transformStyle)
-                           .call(tree.options.contents, tree, transitions)
+
+    selection.call(tree.options.contents, tree, transitions)
 
     if (transitions) {
       enter.style('opacity', 1e-6)

--- a/lib/fly-exit.js
+++ b/lib/fly-exit.js
@@ -9,7 +9,7 @@ module.exports = function (tree) {
     exit.style(tree.prefix + 'transform', transformStyle || defaultStyle.bind(null, source))
         .style('opacity', 1e-6)
 
-    exit.select('div.node-contents')
+    exit.select(':first-child')
         .style(tree.prefix + 'transform', function (d) {
           return 'translate(' + (d.parent ? d.parent._x : 0) + 'px,0px)'
         })

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,67 +1,32 @@
-var d3 = require('d3')
-
 module.exports = function (tree) {
 
   function draw (selection) {
     tree.el.select('.tree')
            .classed('has-transient', false)
 
-    selection.each(function (data, i) {
-      var node = d3.select(this)
-                   .classed('root', !tree.options.forest && i === 0)
-                   .classed('transient', function (d) {
-                     if (d.id === tree.options.transientId) {
-                       tree.el.select('.tree')
-                              .classed('has-transient', true)
-                       return true
-                     }
-                     return false
-                   })
-                   .attr('data-id', function (d) {
-                     return d[tree.options.accessors.id]
-                   })
-
-      node.select('svg.icon')
-          .attr('class', function (d) {
-            return 'icon ' + (tree.nodes[d.id][tree.options.accessors.color] || '') + ' '
-                           + (tree.nodes[d.id][tree.options.accessors.icon] || '')
-          })
-          .select('use')
-          .attr('xlink:href', function (d) {
-            return '#icon-' + tree.nodes[d.id][tree.options.accessors.icon]
-          })
-
-      // change the state of the toggle icon by adjusting its class
-      node.select('.toggler')
-               .attr('class', function (d) {
-                 return 'toggler ' + (d.children ? 'expanded' : d._allChildren && d._allChildren.length ? 'collapsed' : 'leaf')
-               })
-
-      // Perhaps the name changed
-      node.select('div.label')
-                .text(function (d) {
-                  return tree.nodes[d.id][tree.options.accessors.label]
-                })
-
-      // If the tree has indicators, we may need to update the color
-      node.select('div.indicator')
-          .attr('class', function (d) {
-            return 'label-mask indicator ' + tree.nodes[d.id][tree.options.accessors.color]
-          })
-
-      node.style(tree.prefix + 'transform', function (d) {
-            return 'translate(0px,' + d._y + 'px)'
-          })
-          .style('opacity', 1)
-
-      // Now we can move the group so it's indented correctly
-      node.select('div.node-contents')
-          .attr('style', function (d) {
-            return tree.prefix + 'transform:' + 'translate(' + d._x + 'px,0px)'
-          })
-    })
-
-    return selection
+    selection.classed('root', function (d, i) {
+                return !tree.options.forest && i === 0
+              })
+              .classed('transient', function (d) {
+                if (d.id === tree.options.transientId) {
+                  tree.el.select('.tree')
+                         .classed('has-transient', true)
+                  return true
+                }
+                return false
+              })
+              .attr('data-id', function (d) {
+                return d[tree.options.accessors.id]
+              })
+              .style(tree.prefix + 'transform', function (d) {
+                return 'translate(0px,' + d._y + 'px)'
+              })
+             .style('opacity', 1)
+             .call(tree.options.contents, tree)
+             .select(':first-child')
+             .attr('style', function (d) {
+               return tree.prefix + 'transform:' + 'translate(' + d._x + 'px,0px)'
+             })
   }
 
   return draw

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -44,19 +44,28 @@ test('render populates data from stream', function (t) {
   })
 })
 
-test('allows node drawing overrides', function (t) {
+test('allows node contents overrides', function (t) {
   var s = stream()
     , tree = new Tree({
     stream: s,
     contents: function (selection) {
-      selection.append('div')
-               .attr('class', 'node-child')
-               .text(function (d) { return 'node-child-' + d.id })
+      selection.each(function (data) {
+        var node = d3.select(this)
+                     .selectAll('.node-child')
+                     .data(function (d) {
+                       return [d]
+                     })
+
+        node.enter()
+            .append('div')
+              .attr('class', 'node-child')
+              .text(function (d) { return 'node-child-' + d.id })
+      })
     }
   }).render()
 
   s.on('end', function () {
-    t.equal(tree.el.node().querySelectorAll('.tree ul li:first-child')[0].innerHTML, '<div class="node-child">node-child-1001</div>', 'node contents overriden')
+    t.equal(tree.el.node().querySelectorAll('.tree ul li:first-child')[0].innerHTML, '<div class="node-child" style="-webkit-transform:translate(0px,0px)">node-child-1001</div>', 'node contents overriden')
     tree.remove()
     t.end()
   })

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -19,9 +19,12 @@ test('setup', function (t) {
 test('update adjusts node styles', function (t) {
   var updater = update({
       prefix: '-webkit-',
+      _onToggle: Function.prototype,
+      nodes: [[]],
       options: {
         transientId: -1,
         height: 10,
+        contents: require('../lib/contents'),
         accessors: {
           id: 'id'
         }


### PR DESCRIPTION
In the previous implementation, we allowed a `contents` options override
that was used just on `li.node` enter code. But this was broken for two
reasons.
1. The update code (ie. update.js) worked on a node structure that
   banked on contents being the default.
2. All tree code for setting indentation levels used a selector for
   `node-contents`, but if a caller overriding options.contents didn't set
   that class, indentations would break.

This makes the overridable contents be a proper d3 selection, so calling
code can hook into d3 data joining (enter/update/exit).

Fixes #324
