### PR TITLE
Apply transition-duration mixin directly to toggler.

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -201,6 +201,7 @@ $timing-fn: ease-out;
             opacity: 0;
             @include transform(rotate(-90deg));
             @include transform-origin(7px 7px);
+            @include transition-duration($delay);
 
             svg {
               position: absolute;


### PR DESCRIPTION
IE11 didn't like that there wasn't a transition-duration applied directly to the rotating toggler. 

Issue brought up in SB3 here:

https://github.com/SpiderStrategies/Scoreboard/issues/7843