### PR TITLE
WIP Sets a node's z-index to be based on its depth.

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -17,6 +17,9 @@ module.exports = function (tree) {
                      }
                      return false
                    })
+                   .style('z-index', function (d) {
+                     return -d.depth
+                   })
                    .attr('data-id', function (d) {
                      return d[tree.options.accessors.id]
                    })

--- a/tree.scss
+++ b/tree.scss
@@ -5,6 +5,7 @@ $timing-fn: ease-out;
 
 @mixin base-node() {
   list-style: none;
+  background-color: #393c40;
   position: absolute;
   width: 100%;
   height: 36px;
@@ -242,7 +243,6 @@ $timing-fn: ease-out;
 
         &.selected {
           background-color: #2d3135;
-          z-index: 1;
 
           &:not(.placeholder):before {
             content: "";


### PR DESCRIPTION
Now when a node is collapsed to its parent (or some ancestor), it will
be stacked below it. To prevent the lower stacked nodes from bleeding,
the .node needs to have a defined background-color, so that color is now
set in the .node, as well as the .tree-container (so extra space in the
tree has the same color).

e.g.
Root: (z-index 0)
  P1 (z-index -1)
    O1 (z-index -2)
    O2 (z-index -3)
      M1 (z-index -4)
  P2 (z-index -1)

Fixes #338