### PR TITLE
Sets important when we fade out opacity.

### DIFF
--- a/lib/fly-exit.js
+++ b/lib/fly-exit.js
@@ -7,7 +7,7 @@ module.exports = function (tree) {
     // If the node has been removed, we fly it up to its parent
     var exit = selection.exit()
     exit.style(tree.prefix + 'transform', transformStyle || defaultStyle.bind(null, source))
-        .style('opacity', 1e-6)
+        .style('opacity', 1e-6, 'important')
 
     exit.select('div.node-contents')
         .style(tree.prefix + 'transform', function (d) {


### PR DESCRIPTION
Some of the css selectors have an `!important` priority set, which isn't
really ideal, but we set those priorities because we are constantly
changing the inline opacity when we transition nodes in/out.

When a tree was in DND node, the important priority on a node's opacity
was preventing our inline fade out opacity from going to 0, so editable
nodes would never truly fade out.