### PR TITLE
Edit mode - label mask gradient has banding

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -324,7 +324,9 @@ $timing-fn: ease-out;
       }
 
       li.node:not(.transient):not(.selected):not(.transitioning-node) {
-        opacity: .6;
+        .node-contents, .label-mask:after {
+          opacity: .6;
+        }
       }
     }
 


### PR DESCRIPTION
This is for SB3 issue https://github.com/SpiderStrategies/Scoreboard/issues/8469

When lowering the opacity of the background gradient, it can cause extra banding depending monitor or browser. Since its just a transparent to the background color, we can just apply the lowered opacity to what its covering:

<img width="604" alt="screen shot 2016-10-27 at 11 18 31 am" src="https://cloud.githubusercontent.com/assets/3791116/19773506/cacb3da2-9c37-11e6-8d1a-66577184b943.png">
