### PR TITLE
Sets `tree-overflow` on the `.tree` if there is scrollable content.

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,9 @@ Tree.prototype._join = function (data) {
     }
   }
 
+  this.resize(data.length)
   this.el.select('.tree ul').style('height', height)
+
   this.node = this.node.data(data, function (d) {
                          return d[self.options.accessors.id]
                        })
@@ -376,6 +378,30 @@ Tree.prototype._slide = function (source) {
       })
       .call(this.slideExit, source)
       .call(this.updater)
+}
+
+/*
+ * Sets the `tree-overflow` class on the tree node based on `visibleNodes` length.
+ * `visibleNodes` is optional. If it's not received, we look up how many nodes are visible.
+ * But for performance reasons we allow an incoming argument to control how
+ * many nodes are visible in case this number is already known.
+ *
+ * This doesn't actually resize the tree, it should be fired after the size of the tree container
+ * has been changed.
+ *
+ */
+Tree.prototype.resize = function (visibleNodes) {
+  if (visibleNodes === undefined) {
+    visibleNodes = this.el.selectAll('.tree ul li')
+                          .data().length
+  }
+  var height = this.options.height
+  this.el.select('.tree')
+         .classed('tree-overflow', function () {
+           return this.offsetHeight < visibleNodes * height
+         })
+
+  return this
 }
 
 /*

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -840,3 +840,27 @@ test('click toggler disabled on root', function (t) {
 
   tree.render()
 })
+
+test('sets `tree-overflow` based on scrollable content', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s})
+    , container = document.createElement('div')
+
+  container.style.height = '100px'
+  document.body.appendChild(container)
+  s.on('end', function () {
+    container.appendChild(tree.el.node())
+    t.ok(tree.el.select('.tree').classed('tree-overflow'), 'tree has `tree-overflow`')
+    container.style.height = '2000px'
+    tree.resize()
+    t.notOk(tree.el.select('.tree').classed('tree-overflow'), 'tree does not have `tree-overflow`')
+
+    tree.resize(10000) // exaggerate number of nodes
+    t.ok(tree.el.select('.tree').classed('tree-overflow'), 'tree is marked `tree-overflow` with visibleNodes set')
+    container.remove()
+
+    t.end()
+  })
+
+  tree.render()
+})

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -166,6 +166,23 @@ test('root node has a class of root', function (t) {
   })
 })
 
+test('tree drawing adjusts `tree-overflow` based on bound node data', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s}).render()
+    , container = document.createElement('div')
+
+  container.style.height = '50px'
+
+  document.body.appendChild(container)
+  s.on('end', function () {
+    container.appendChild(tree.el.node())
+    t.ok(tree.el.select('.tree').classed('tree-overflow'), 'tree overflow set')
+    tree.remove()
+    container.remove()
+    t.end()
+  })
+})
+
 test('displays a node as selected on render', function (t) {
   var s = stream()
     , tree = new Tree({

--- a/tree.scss
+++ b/tree.scss
@@ -73,15 +73,22 @@ $timing-fn: ease-out;
      * So this disables the fade-in effect in IE11, so the translate transformation
      * looks good.
      */
-    .tree.transitions {
-      ul {
-        li.node {
-          &.incoming-node {
-            opacity: 1;
+    .tree {
+      &.tree-overflow {
+        overflow-y: scroll;
+      }
+
+      &.transitions {
+        ul {
+          li.node {
+            &.incoming-node {
+              opacity: 1;
+            }
           }
         }
       }
     }
+
   }
 
   .traveling-node {


### PR DESCRIPTION
Then adds a new selector to `.ie-trident` which gives the `.tree`
`overflow-y: auto` so scrollbars are shown in IE. This prevents the
scrollbar from covering content on the far right, which happens in IE
because of li nodes being absolute positioned.

Fixes #349