### PR TITLE
Force overflow:visible on li.nodes

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -11,7 +11,15 @@ $timing-fn: ease-out;
   height: 36px;
   top: 0;
   left: 0;
-  overflow-x: hidden;
+
+  /*
+   * This seems weird, and it is, but in FF (See #364), when nodes are moved in the tree, when you go to update some innerHTML of the node
+   * the node text disappears. It seems to be a bug introduced in FF 25 (worked fine up until FF 24.8). Forcing a node's overflow to visible
+   * forces FF to not make the innerHTML of the `.label` vanish. Somewhat surprisingly, overflow of visible is okay since we're using label masking.
+   * See a simplified demo of the bug here: http://codepen.io/anon/pen/VmRROj
+   */
+  overflow: visible;
+
   @include transition-property(opacity);
   @include transition-duration($delay);
   @include transition-timing-function($timing-fn);
@@ -210,7 +218,6 @@ $timing-fn: ease-out;
       li.node {
         @include base-node;
         cursor: pointer;
-        overflow-y: hidden;
 
         &.transitioning-node {
           pointer-events: none;


### PR DESCRIPTION
This seems to be necessary because of a firefox rendering bug. The
problem can be demonstrated here:

http://codepen.io/anon/pen/VmRROj

When the li.node has overflow-x and overflow-y `hidden`, firefox will
break on `li.node .node-contents .label` innerHTML changes. After a node
moves, if you try to change its label, the label disappears from the
browser, even though inspecting them dom shows the label is correct.
Removing these properties altogether work in the tree project, but still
show bugs in SB3 (driving force behind this project), but forcing
overflow to visible seems to hide the problem in FF. Seems like one of
those "This fixes it, but shouldn't" commits.

It's also scary removing the hidden property, but it seems like we're
okay without out, since we're using label-mask.

Fixes #344
Also Fixes Sb3 issue #9216