### PR TITLE
Styles transitioning-placeholder so its contents are hidden and has a

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -257,7 +257,12 @@ $timing-fn: ease-out;
           }
         }
 
-        &.placeholder {
+        &.placeholder, &.transition-placeholder {
+          &.transition-placeholder {
+            // This is for transition placeholder nodes popping in or out
+            background-color: #2d3135 !important;
+          }
+
           * {
             display: none;
           }


### PR DESCRIPTION
background.

This was previously defined, but we introduced a bug when we added the
placeholder class for a traveling node (dnd).