### PR TITLE
Long org names show in scrollbar when overflowing

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -25,7 +25,7 @@ module.exports = function (tree) {
              .call(tree.options.contents, tree)
              .select(':first-child')
              .attr('style', function (d) {
-               return tree.prefix + 'transform:' + 'translate(' + d._x + 'px,0px)'
+               return tree.prefix + 'transform:' + 'translate(' + d._x + 'px,0px); max-width: calc(100% - ' + d._x + 'px)'
              })
 
 


### PR DESCRIPTION
A possible solution for SB3 issue: https://github.com/SpiderStrategies/Scoreboard/issues/9792

The issue is caused by the `overflow: visible` property being set for #364