### PR TITLE
Changes add animation when the new node's parent is being expanded.

### DIFF
--- a/index.js
+++ b/index.js
@@ -797,6 +797,14 @@ Tree.prototype.add = function (d, parent, idx) {
     return
   }
 
+  if (parent && parent.selected) {
+    // The parent is selected, we want to expand its children (#259)
+    delete parent.collapsed
+    // Show the children immediately
+    this._fly()
+    this._forceRedraw()
+  }
+
   _d.parent = parent
   this.nodes[d.id] = d
   this._layout[_d.id] = _d
@@ -808,11 +816,6 @@ Tree.prototype.add = function (d, parent, idx) {
       parent._allChildren = []
     }
     parent._allChildren.push(_d)
-  }
-
-  if (parent && parent.selected) {
-    // The parent is selected, we want to expand its children (#259)
-    delete parent.collapsed
   }
 
   this._transitionWrap(this._slide)()

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -636,18 +636,24 @@ test('add node toggles tree nodes if parent is selected', function (t) {
     t.ok(!tree._layout[1003].children, 'selected node is not expanded so it does not have children')
     t.equal(el.querySelectorAll('.tree ul li.node').length, 8, '8 nodes visible')
 
+    var redraw = tree._forceRedraw
+    tree._forceRedraw = function () {
+      // Intercept this call to verify the parent is expanded
+      t.ok(tree._layout[1003].children, 'parent is now expanded')
+      t.equal(el.querySelectorAll('.tree ul li.node').length, 18, '18 nodes visible')
+      tree._forceRedraw = redraw // for next time
+
+      process.nextTick(function () {
+        t.equal(el.querySelectorAll('.tree ul li.node').length, 19, '19 nodes visible')
+        t.end()
+      })
+    }
     var d = tree.add({
       id: 3020,
       label: 'Newest node sibling',
       color: 'green',
       nodeType: 'metric'
     }, 1003)
-
-    process.nextTick(function () {
-      t.ok(tree._layout[1003].children, 'parent is now expanded')
-      t.equal(el.querySelectorAll('.tree ul li.node').length, 19, '19 nodes visible')
-      t.end()
-    })
 
   })
 })


### PR DESCRIPTION
Previously nodes that weren't new, but were just collapsed, were
receiving new node styling. This changes the add logic so a new node
that is part of a collapsed and selected parent has new node styling,
but its siblings will be shown right away.