### PR TITLE
Binds dnd `droppable` callback's `this` to the tree.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ new Tree({
   forest: false, // Indicates whether this tree can have multiple root nodes
   movable: function (d) { // control if a node can be moved
     // `d` is the node
+    // `this` is a reference to the tree
     return true
   },
   droppable: function (d, parent) {
     // `d` is the node being moved
     // `parent` is its new parent. May be undefined if node is being moved to root in a forest tree
-
+    // `this` is a reference to the tree
     return true // By default, any node can be dropped on any other node
   },
   contents: require('./lib/contents'), // Override the default html structure of each node

--- a/index.js
+++ b/index.js
@@ -38,12 +38,13 @@ var defaults = function () {
     forest: false, // Indicates whether this tree can have multiple root nodes
     movable: function (d) {
       // `d` is the node
+      // `this` is a reference to the tree
       return true
     },
     droppable: function (d, parent) {
       // `d` is the node being moved
       // `parent` is its new parent. May be undefined if node is being moved to root in a forest tree
-
+      // `this` is a reference to the tree
       return true // By default, any node can be dropped on any other node
     },
     contents: require('./lib/contents'),

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -330,14 +330,14 @@ Dnd.prototype._move = function (y, d) {
       var newParent = self._parent(d._source, target, previous, embed)
         , illegal = false
 
-      if (!self.tree.options.droppable(self.tree.nodes[d._source.id], self.tree.nodes[newParent && newParent.id])) {
+      if (!self.tree.options.droppable.call(self.tree, self.tree.nodes[d._source.id], self.tree.nodes[newParent && newParent.id])) {
         illegal = true
         // This is an illegal operation.
         if (embed) {
           // They were trying to embed the node, but that's not allowed, so make this not embedded, and grab the new parent
           newParent = newParent.parent
           embed = false
-          illegal = !self.tree.options.droppable(self.tree.nodes[d._source.id], self.tree.nodes[newParent && newParent.id])
+          illegal = !self.tree.options.droppable.call(self.tree, self.tree.nodes[d._source.id], self.tree.nodes[newParent && newParent.id])
         }
       }
       d.illegal = illegal

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -324,11 +324,14 @@ test('dnd autoscrolls', function (t) {
 })
 
 test('`movable` allows control to prevent if a node can be dnd\d', function (t) {
+  t.plan(3)
   before(function (tree, dnd) {
     var node = tree.node.nodes()[3]
       , data = tree._layout[1058]
+      , that = null
 
     tree.options.movable = function (d, parent) {
+      that = this // save to test later
       return d.nodeType !== 'metric'
     }
 
@@ -336,6 +339,8 @@ test('`movable` allows control to prevent if a node can be dnd\d', function (t) 
 
     t.equal(tree.el.selectAll('.node').size(), 18, '18 nodes')
     t.equal(tree.el.selectAll('.node.movable').size(), 8, '8 movable nodes')
+    t.equal(that, tree, 'movable `this` (our that) is bound to the tree')
+
     tree.remove()
     document.querySelector('.container').remove()
     t.end()
@@ -346,8 +351,10 @@ test('disable non-metrics dropped onto metrics', function (t) {
   before(function (tree, dnd) {
     var node = tree.node.nodes()[3]
       , data = tree._layout[1058]
+      , that = null
 
     tree.options.droppable = function (d, parent) {
+      that = this
       if (d.nodeType === 'metric') {
         // Metrics can go anywhere
         return true
@@ -365,6 +372,7 @@ test('disable non-metrics dropped onto metrics', function (t) {
     d3.event.y = 290 // This would move 1058 onto 1008 which is a metric
     dnd.drag.apply(node, [data, 3])
 
+    t.equal(that, tree, 'droppable this is the tree')
     t.equal(data._x, tree._layout[1008]._x, '1058 is a sibling of 1008')
 
     tree.once('move', function (n, newParent, previousParent, newIndex, previousIndex) {


### PR DESCRIPTION
This matches the movable callback.

Adds tests.

Fixes #371