### PR TITLE
Remove unnecessary .lastIndex call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1099,7 +1099,6 @@ Tree.prototype.search = function (term) {
     , self = this
 
   this.filter(term && function (node) {
-    re.lastIndex = 0
     return re.test(node[self.options.accessors.label]) && node.visible !== false
   })
 }


### PR DESCRIPTION
The `.lastIndex` call is only needed if you are working with "sticky" regular expressions using the "y" flag passed to the constructor

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp