### PR TITLE
Emits `rendered` events after we're done transitioning the tree.

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,12 +248,18 @@ Tree.prototype._transitionWrap = function (fn, animate, force) {
       self.el.select('.tree').classed('transitions', true)
     }
 
-    var result = fn.apply(self, arguments)
     if (animate) {
-      self.el.selectAll('.node')
-               .on('transitionend', function () {
-                 self.el.select('.tree').classed('transitions', false)
-               })
+      setTimeout(function () {
+        self.el.select('.tree').classed('transitions', false)
+        self.emit('rendered')
+      }, self.transitionTimeout)
+    }
+
+    var result = fn.apply(self, arguments)
+
+    if (!animate) {
+      // Fire right away once we're done updating the dom
+      self.emit('rendered')
     }
 
     return result

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -333,21 +333,25 @@ test('transitioning-node applied to entering nodes', function (t) {
   tree.render()
 })
 
-test('disables animations if opts.maxAnimatable is exceeded', function (t) {
+test('disables transitions animation if opts.maxAnimatable is exceeded', function (t) {
+  t.plan(3)
   var s = stream()
     , tree = new Tree({stream: s, maxAnimatable: 3}).render()
 
   s.on('end', function () {
     var toggler = tree.toggle
+
+    tree.on('rendered', function () {
+      t.ok(!tree.el.select('.tree').classed('transitions'), 'tree does not have transitions class after toggle')
+      tree.remove()
+      t.end()
+    })
+
     tree.toggle = function () {
       t.ok(!tree.el.select('.tree').classed('transitions'), 'tree does not have transitions class applied')
       toggler.apply(tree, arguments)
-      process.nextTick(function () {
-        t.ok(!tree.el.select('.tree').classed('transitions'), 'tree does not have transitions class after toggle')
-        tree.remove()
-        t.end()
-      })
     }
+
     t.ok(!tree._layout[1003].children, 10, '1003 hidden nodes')
     tree.select(1002)
   })


### PR DESCRIPTION
Previously we listened to `transitionend` on the node selection. This
would fire multiple times for each node that was moving, since
transitionend fires for each property that's changing. For a node in the
tree, that could be its `opacity`, `transform left`, and/or `transform
top`. This approach uses the timeout setting we for transitions, so the
callback is fired just once. When the nodes are done moving/updating, we
remove the `transitions` class on the tree, and fire a tree
`transitionend` event for any interested parties.