### PR TITLE
Allows trees to have incoming `editable` option so it's editable on

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ Tree.prototype.render = function () {
 
   this.node = this.el.append('div')
                        .attr('class', 'tree')
+                       .classed('editable', this.options.editable) // In case trees are initialized with `editable: true`
                        .on('scroll', function () {
                          var scroll = self.el.select('.tree').node().scrollTop
                          if (!self._scrollTop) {

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -95,6 +95,21 @@ test('allows node contents overrides', function (t) {
   })
 })
 
+test('tree can be editable on initial render based on options', function (t) {
+  var s = stream()
+    , tree = new Tree({
+      stream: s,
+      editable: true
+    }).render()
+
+  s.on('end', function () {
+    t.ok(tree.el.node().querySelector('.tree.editable'), 'tree is marked as editable')
+    t.ok(tree.isEditable(), 'the tree is editable according to its api')
+    tree.remove()
+    t.end()
+  })
+})
+
 test('does not apply indicator class to label-mask by default', function (t) {
   var s = stream()
     , tree = new Tree({stream: s}).render()


### PR DESCRIPTION
initial render.