### PR TITLE
Remove `transition: none` for edit mode transition nodes.

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -354,8 +354,6 @@ $timing-fn: ease-out;
       li.node:not(.transient):not(.selected):not(.transitioning-node) {
         .node-contents, .label-mask:after {
           opacity: .6;
-          // Prevent IE11 from breaking due to another opacity transition bug
-          transition: none;
         }
       }
     }


### PR DESCRIPTION
In
https://github.com/SpiderStrategies/kalpa-tree/commit/579c3c8192fe009122d1a7e3985a1f1d2823e254
we added this transition: none; to fix an issue with IE11. Derek and I
remember testing this change with @scottoreilly, but apparently we
missed something. When I go back to this commit, it's what introduced
the new bug in Sb3 (#12556). It doesn't appear like this `transition:
none;` is needed.

Other issues for history:
https://github.com/SpiderStrategies/Scoreboard/issues/8950
https://github.com/SpiderStrategies/kalpa-tree/pull/362
https://github.com/SpiderStrategies/kalpa-tree/pull/363

Fixes https://github.com/SpiderStrategies/Scoreboard/issues/12556