### PR TITLE
Uses `classed` on enter nodes instead of overriding classes.

### DIFF
--- a/lib/enter.js
+++ b/lib/enter.js
@@ -5,7 +5,7 @@ module.exports = function (tree) {
   return function (enter, transformStyle, cssClasses) {
     var transitions = tree.el.select('.tree').classed('transitions')
 
-    enter.attr('class', 'node ' + (cssClasses || ''))
+    enter.classed('node ' + (cssClasses || ''), true) // Don't set `attr('class')` b/c it could overwrite some previous setting
          .classed('selected', function (d) {
            return d.selected
          })


### PR DESCRIPTION
This is needed when incoming nodes (from an expand) are set to
`movable`. When enter is called, it was overwriting the classes.

For https://github.com/SpiderStrategies/Scoreboard/issues/14263