### PR TITLE
Allows new option `indentableSelector` to control which node receives a

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ var defaults = function () {
       })
     },
     contents: require('./lib/contents'),
+    indentableSelector: ':first-child', // The element within the `.node` which will be used for showing tree indentations
+                                        // Only need to update if using different `contents`
     performanceThreshold: 1000, // If the node data count exceeds this threshold, the tree goes into performance mode
     accessors: {
       id: 'id',

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -401,7 +401,7 @@ Dnd.prototype._move = function (y, d) {
   .classed('illegal', function (d) {
     return d.illegal
   })
-  .select(':first-child')
+  .select(this.tree.options.indentableSelector)
     .attr('style', function (d) {
       // Set the indentation of the traveling node to equal the original node's position, since it
       // will be moved automatically

--- a/lib/fly-exit.js
+++ b/lib/fly-exit.js
@@ -6,7 +6,7 @@ module.exports = function (tree) {
   return function (exit, source, transformStyle) {
     // If the node has been removed, we fly it up to its parent
     exit.style(tree.prefix + 'transform', transformStyle || defaultStyle.bind(null, source))
-        .select(':first-child')
+        .select(tree.options.indentableSelector)
         .style(tree.prefix + 'transform', function (d) {
           return 'translate3d(' + (d.parent ? d.parent._x : 0) + 'px,0px,0px)'
         })

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,4 +1,5 @@
 var d3 = require('d3-selection')
+
 module.exports = function (tree) {
 
   return function (selection) {
@@ -23,7 +24,7 @@ module.exports = function (tree) {
                 return 'translate3d(0px,' + d._y + 'px,0px)'
               })
               .call(tree.options.contents, tree)
-              .select(':first-child')
+              .select(tree.options.indentableSelector)
               .attr('style', function (d) {
                 return tree.prefix + 'transform:' + 'translate3d(' + d._x + 'px,0px,0px)'
               })

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -27,6 +27,7 @@ test('update adjusts node styles', function (t) {
         label: function () {
           // filler
         },
+        indentableSelector: ':first-child',
         contents: require('../lib/contents'),
         accessors: {
           id: 'id'


### PR DESCRIPTION
translateX transform.

This is used when someone is overriding default node contents.