### PR TITLE
Allows a `expandTo` flag to prevent showing a copied/moved node in the

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,7 +517,7 @@ Tree.prototype.previousSibling = function (obj) {
  * If an optional index is received, the node will be inserted at that index within the
  * `to`'s children.
  */
-Tree.prototype.move = function (node, to, idx) {
+Tree.prototype.move = function (node, to, idx, expandAncestors = true) {
   var _node = getObject(this._layout, node)
   if (!node) {
     return
@@ -530,7 +530,10 @@ Tree.prototype.move = function (node, to, idx) {
     delete _to.collapsed
     var children = (_to._allChildren || (_to._allChildren = []))
     children.splice(typeof idx === 'number' ? idx : children.length, 0, _node)
-    this._expandAncestors(_to)
+    _node.parent = _to
+    if (expandAncestors) {
+      this._expandAncestors(_to)
+    }
   } else if (this.options.forest) {
     this._removeFromParent(_node)
     this.root.splice(typeof idx === 'number' ? idx : this.root.length, 0, _node)
@@ -557,7 +560,7 @@ Tree.prototype._descendants = function (node, prop) {
  * If to is missing and the tree is a forest, the node will be copied
  * to a new root node of the forest tree.
  */
-Tree.prototype.copy = function (node, to, transformer) {
+Tree.prototype.copy = function (node, to, transformer, expandAncestors = true) {
   var _node = getObject(this._layout, node)
   if (!_node) {
     return
@@ -592,7 +595,11 @@ Tree.prototype.copy = function (node, to, transformer) {
           // Top node in the subtree (node that is being copied)
           if (_to) {
             ;(_to._allChildren || (_to._allChildren = [])).push(d)
-            self._expandAncestors(_to)
+
+            if (expandAncestors) {
+              self._expandAncestors(_to)
+            }
+
             _to.collapsed = false
           } else if (self.options.forest) {
             self.root.push(d)

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -78,12 +78,34 @@ test('moves a node', function (t) {
     var orgParent = tree._layout[1003].parent
       , orgChildrenLength = orgParent._allChildren.length
 
+    t.notOk(tree._layout[1003].parent.children, 'new parent is not expanded')
     tree.move(1003, 1025)
+    process.nextTick(function () {
+      t.equal(orgParent._allChildren.length, orgChildrenLength - 1, 'orginal parent is missing a child')
+      t.deepEqual(tree._layout[1003].parent, tree._layout[1025], 'moved node has new parent')
+      t.equal(tree._layout[1003].parent.children.length, 5, 'new parent is expanded')
+      t.deepEqual(tree._layout[1025]._allChildren[tree._layout[1025]._allChildren.length -1], tree._layout[1003], '1003 was pushed to end of 1025')
+      t.end()
+    })
+  })
+})
+
+test('moves a node without showing new layout', function (t) {
+   var s = stream()
+    , tree = new Tree({stream: s}).render()
+    , el = tree.el.node()
+
+  s.on('end', function () {
+    var orgParent = tree._layout[1003].parent
+      , orgChildrenLength = orgParent._allChildren.length
+
+    t.notOk(tree._layout[1003].parent.children, 'new parent is not expanded')
+    tree.move(1003, 1025, null, false)
 
     process.nextTick(function () {
       t.equal(orgParent._allChildren.length, orgChildrenLength - 1, 'orginal parent is missing a child')
       t.deepEqual(tree._layout[1003].parent, tree._layout[1025], 'moved node has new parent')
-      t.deepEqual(tree._layout[1025]._allChildren[tree._layout[1025]._allChildren.length -1], tree._layout[1003], '1003 was pushed to end of 1025')
+      t.notOk(tree._layout[1003].parent.children, 'new parent is still not expanded')
       t.end()
     })
   })


### PR DESCRIPTION
tree.

For https://github.com/SpiderStrategies/Scoreboard/issues/15512