### PR TITLE
Fires a true `click` event on the node if that's what we're forcing if

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -47,7 +47,13 @@ var Dnd = function (tree) {
 
     if (self.traveler && (new Date() - self._startMs < self.tree.options.dndDelay)) {
       self._restore()
-      tree._onSelect(self.traveler.datum()._source)
+      // D3 dnd code overrides all the events. We want to treat this is as a normal click, in case
+      // some outside code has an event listener attached. After this current event loop has finished
+      // fire the normal click event.
+      var node = this
+      process.nextTick(function () {
+        node.click()
+      })
     }
     self._end(d, this)
   }


### PR DESCRIPTION
the dnd was "too short". This allows outside code event bubbling to work
since d3 cancels all events if it's handling dnd.

For https://github.com/SpiderStrategies/Scoreboard/issues/16181