### PR TITLE
Force a z-index stack with a translateZ on the `.tree`

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -169,6 +169,8 @@ $timing-fn: ease-out;
   .tree {
     overflow: auto;
     overflow-x: hidden;
+    transform: translateZ(0); // Each node has a translate3D for positioning, so safari creates a z-index stack which puts the node in front of the scrollbar container
+                              // This forces the scrollbars to be on top of the nodes. See https://github.com/SpiderStrategies/Scoreboard/issues/17021
     -webkit-overflow-scrolling: touch;
 
     width: 100%;


### PR DESCRIPTION
Since each node has a translate3d with a 0px z value, safari shows the
scrollbars for the .tree node behind the node itself.

For https://github.com/SpiderStrategies/Scoreboard/issues/17021