### PR TITLE
illegal drag state

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -131,11 +131,11 @@ $timing-fn: ease-out;
         opacity: .7;
 
         .icon {
-          fill: #3a4045;
+          fill: #f35132;
         }
 
         .label {
-          color: #3a4045;
+          color: #f35132;
         }
       }
 


### PR DESCRIPTION
This is to address the following comment in https://github.com/SpiderStrategies/Scoreboard/issues/18096

Should be safe to put here because we don't handle the illegal state styles in SB3 from what I can tell. 

> When you drag an item someplace it can't go, we have a red error style. The drag icon looks like it's correct, but I think the text is supposed to be red too.