### PR TITLE
If the tree is `tuned`, make sure it doesn't have the transitions class.

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,6 +332,8 @@ Tree.prototype._join = function (data, next) {
                   return inside
                 })
     if (this._tuned) {
+      // Make sure the tree isn't animating
+      this.el.select('.tree').classed('transitions', false)
       height = last._y + this.options.height + this._rootOffset + 'px'
     }
   }


### PR DESCRIPTION
Some calls are fired: `_transitionWrap` -> `rebind` -> `join`, and join
determines if we need to tune the tree. But the `transitions` class
might have already been set by the transitionWrap call, so this removes
the class name if we're tuned.

For https://github.com/SpiderStrategies/Scoreboard/issues/19155