### PR TITLE
Call `enter` on removeNode when performance tuned.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1086,6 +1086,11 @@ Tree.prototype.removeNode = function (obj) {
   // Redraw
   this._transitionWrap(function () {
     this._rebind(function (enter, update, exit) {
+      if (self._tuned) {
+        // If we're tuned we may have entering nodes because they weren't previously in the DOM, but they are now since they are "moving up".
+        // We don't need to call enter most of the time because the nodes are already in the DOM
+        enter.call(self.enter)
+      }
       update.call(self.updater)
       exit.call(self.slideExit, _node)
     })

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -592,6 +592,31 @@ test('removes root', function (t) {
   tree.render()
 })
 
+test('removeNode calls `enter` when the tree is performance tuned', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s, performanceThreshold: 0})
+    , container = document.createElement('div')
+
+  container.style.height = '50px'
+  document.body.appendChild(container)
+
+  s.on('end', function () {
+    container.appendChild(tree.el.node())
+    process.nextTick(function () {
+      tree.expandAll()
+      tree.removeNode(1003)
+
+      setTimeout(function () {
+        t.equal(tree.el.node().querySelectorAll('li.node').length, 4, '4 li.node in tree')
+        tree.remove()
+        container.remove()
+        t.end()
+      }, 400)
+    })
+  })
+  tree.render()
+})
+
 test('adds a new root', function (t) {
   var s = stream()
     , tree = new Tree({stream: s})


### PR DESCRIPTION
DOM nodes could be created since they previously weren't in the DOM, so
we need to make sure they have the proper classes.

For https://github.com/SpiderStrategies/Scoreboard/issues/19155