### PR TITLE
Nixes hardware acceleration

### DIFF
--- a/tree.scss
+++ b/tree.scss
@@ -169,8 +169,6 @@ $timing-fn: ease-out;
   .tree {
     overflow: auto;
     overflow-x: hidden;
-    transform: translateZ(0); // Each node has a translate3D for positioning, so safari creates a z-index stack which puts the node in front of the scrollbar container
-                              // This forces the scrollbars to be on top of the nodes. See https://github.com/SpiderStrategies/Scoreboard/issues/17021
     -webkit-overflow-scrolling: touch;
 
     width: 100%;


### PR DESCRIPTION
This nixes hardware acceleration in order to address https://github.com/SpiderStrategies/Scoreboard/issues/19595

For posterity, an explanation. We're nixing hardware acceleration here because it appears the following issues for which it was introduced are no longer problems.
1. https://github.com/SpiderStrategies/scoreboard-gantt/issues/67
    - *This was re-confirmed a problem w/o hardware acceleration in Safari 10.x but is no longer a problem in Safari 11.x w/o hardware acceleration*
2. https://github.com/SpiderStrategies/Scoreboard/issues/9792
    - *This appears to no longer be a problem for Safari 10.x or 11.x without hardware acceleration*
3. https://github.com/SpiderStrategies/Scoreboard/issues/9031
    - *This appears to no longer be a problem for Safari 10.x or 11.x without hardware acceleration*
4. https://github.com/SpiderStrategies/Scoreboard/issues/17017
    - *This appears to no longer be a problem for Safari 10.x or 11.x without hardware acceleration*
