### PR TITLE
Adds defensive checks when clearing filtered tree results so forest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1142,7 +1142,17 @@ Tree.prototype.removeNode = function (obj) {
  */
 Tree.prototype.filter = function (fn) {
   if (fn == null) {
-    return this.select((this._selected && this._selected.id) || (this.options.forest ? this.root[0].id : this.root.id), {
+    let selected = this._selected // default to the previously selected node
+    if (!selected) {
+      // Previously didn't have a selected node, so we'll select the root node
+      if (this.options.forest) {
+        // Top of the forest if it has nodes
+        selected = this.root.length ? this.root[0] : null
+      } else {
+        selected = this.root
+      }
+    }
+    return this.select(selected && selected.id, {
       force: this.el.select('.tree').classed('filtered-results'),
       silent: true
     })

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -4,6 +4,7 @@ var test = require('tape').test
   , Tree = require('../')
   , stream = require('./tree-stream')
   , Transform = require('stream').Transform
+  , PassThrough = require('stream').PassThrough
 
 function container () {
   var container = document.createElement('div')
@@ -126,6 +127,13 @@ test('search for null clears search', function (t) {
     c.remove()
     t.end()
   })
+})
+
+test('empty forest null search', function (t) {
+  let tree = new Tree({stream: new PassThrough, forest: true}).render()
+  tree.search(null)
+  t.ok(!tree.el.select('.tree').classed('filtered-results'), 'tree does not have filtered-results class')
+  t.end()
 })
 
 test('clearing search does not fire select event', function (t) {


### PR DESCRIPTION
trees without nodes don't cause JS blowups.

For https://github.com/SpiderStrategies/Scoreboard/issues/21602