### PR TITLE
Adds `expandedNodes` method to the tree.

### DIFF
--- a/index.js
+++ b/index.js
@@ -848,7 +848,7 @@ Tree.prototype._store = function (node, parent, idx) {
   var p = parent || this._layout[node.parentId]
     , _n = this._layout[node.id] = { // internal version which we'll use to modify the node's layout
       id: node.id,
-      collapsed: true // by default incoming nodes are collapsed
+      collapsed: typeof node.collapsed === 'undefined' ? true : node.collapsed // by default incoming nodes are collapsed
     }
 
   if (node.visible === false) {

--- a/index.js
+++ b/index.js
@@ -1333,4 +1333,12 @@ Tree.prototype.removeTransient = function () {
   this.removeNode(this.options.transientId)
 }
 
+/*
+ * Returns the currently expanded nodes
+ */
+Tree.prototype.expandedNodes = function () {
+  return this._layout.filter(node => !node.collapsed)
+                     .map(node => this.nodes[node.id])
+}
+
 module.exports = Tree

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -1097,3 +1097,25 @@ test('emits `rebind` event when rebinding data', function (t) {
 
   tree.render()
 })
+
+test('returns expanded nodes', function (t) {
+  var s = stream()
+    , tree = new Tree({stream: s})
+
+  t.plan(4)
+
+  tree.on('rendered', () => {
+    t.equal(tree.expandedNodes().length, 1, 'one expanded node')
+    t.equal(tree.expandedNodes()[0].id, 1001, 'root is only expanded node')
+
+    tree.select(1003)
+
+    t.equal(tree.expandedNodes().length, 3, 'three expanded nodes')
+
+    tree.expandAll()
+    t.equal(tree.expandedNodes().length, Object.keys(tree.nodes).length, 'All nodes are expanded')
+
+    t.end()
+  })
+  tree.render()
+})

--- a/test/tree-drawing-test.js
+++ b/test/tree-drawing-test.js
@@ -212,6 +212,39 @@ test('render populates and hides visible: false nodes', function (t) {
   })
 })
 
+test('initial render respects `collapsed` property on the nodes', (t) => {
+  t.plan(5)
+  var map = new Transform( { objectMode: true } )
+    , expand = [1002, 1070, 1081]
+
+  map._transform = function(obj, encoding, done) {
+    if (expand.indexOf(obj.id) !== -1) {
+      obj.collapsed = false
+    }
+    this.push(obj)
+    done()
+  }
+
+  var s = stream()
+    , mapStream = s.pipe(map)
+    , tree = new Tree({stream: mapStream }).render()
+
+  tree.on('rendered', function () {
+    let expandedNodes = tree.expandedNodes()
+                            .map(node => node.id)
+
+    t.equal(expandedNodes.length, 4, '4 expanded nodes')
+
+    t.equal(expandedNodes[0], 1001, 'root expanded')
+
+    expand.forEach(id => {
+      t.ok(expandedNodes.indexOf(id) != -1, `${id} is expanded`)
+    })
+
+    t.end()
+  })
+})
+
 test('displays root and its children by default', function (t) {
   var s = stream()
     , tree = new Tree({stream: s})


### PR DESCRIPTION
This returns all the nodes that are expanded.

Fixes #448