### PR TITLE
mark colored icons with .has-color

### DIFF
--- a/lib/contents.js
+++ b/lib/contents.js
@@ -58,7 +58,8 @@ module.exports = function (selection, tree, transitions) {
 
     contents.select('svg.icon')
             .attr('class', function (d) {
-              return 'icon ' + (tree.nodes[d.id][tree.options.accessors.color] || '')
+              var color = tree.nodes[d.id][tree.options.accessors.color]
+              return 'icon ' + (color ? color + ' has-color' : '')
                              + (' icon-' + (field(d.id, tree.options.accessors.icon) || ''))
             })
             .select('use')


### PR DESCRIPTION
Marks colored tree icons with `.has-color` for easier style overriding