### PR TITLE
dnd `droppable` callback node has the original state before drag tacked

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -333,9 +333,12 @@ Dnd.prototype._children = function (d, parent, children) {
  * A traveling node is `illegal` if it's not droppable (based on the user defined droppable callback) or
  * its parent is a transient node.
  */
-Dnd.prototype._isIllegal = function (source, newParent) {
+Dnd.prototype._isIllegal = function (source, newParent, beforeDragState) {
+  let node = Object.assign({}, this.tree.nodes[source.id], {
+    beforeDragState // Tack the original state before dnd started onto the node
+  })
   return ((newParent && newParent.id) == this.tree.options.transientId)
-         || !this.tree.options.droppable.call(this.tree, this.tree.nodes[source.id], this.tree.nodes[newParent && newParent.id])
+         || !this.tree.options.droppable.call(this.tree, node, this.tree.nodes[newParent && newParent.id])
 
 }
 
@@ -355,8 +358,12 @@ Dnd.prototype._move = function (y, d) {
       // This means we're modifying the data in the tree or the node's embedded property has now changed
       var newParent = self._parent(d._source, target, previous, embed)
         , illegal = false
+        , originalState = {
+          index: d._initialIndex,
+          parent: d._initialParent
+        }
 
-      if (self._isIllegal(d._source, newParent)) {
+      if (self._isIllegal(d._source, newParent, originalState)) {
         illegal = true
         // This is an illegal operation.
         if (embed) {
@@ -368,7 +375,7 @@ Dnd.prototype._move = function (y, d) {
                                   // This is needed to prevent newParent being undefined for non forest trees, which doesn't make sense.
           }
           embed = false
-          illegal = self._isIllegal(d._source, newParent)
+          illegal = self._isIllegal(d._source, newParent, originalState)
         }
       }
 

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -401,6 +401,31 @@ test('`movable` allows control to prevent if a node can be dnd\d', function (t) 
   })
 })
 
+test('droppable call node has original state', function (t) {
+  t.plan(1)
+  before(function (tree, dnd) {
+    var node = tree.node.nodes()[3]
+      , data = tree._layout[1058]
+      , that = null
+
+    tree.options.droppable = function (d, parent) {
+      t.deepEqual(d.beforeDragState, { index: 1, parent: 1001 }, 'before drag state stored')
+      return true
+    }
+
+    tree.editable()
+    dnd.start.apply(node, [data, 3])
+    dnd._dragging = true
+    d3.event.y = 290
+    dnd.drag.apply(node, [data, 3])
+    dnd.end.apply(node, [data, 3])
+
+    tree.remove()
+    document.querySelector('.container').remove()
+    t.end()
+  })
+})
+
 test('restores tree if dropped illegally', function (t) {
   before(function (tree, dnd) {
     var node = tree.node.nodes()[3]


### PR DESCRIPTION
onto it.

For