### PR TITLE
Prevents auto scrolling if the current node auto scroll position is

### DIFF
--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -186,6 +186,12 @@ Dnd.prototype._autoscroll = function (d, tree, y) {
     return
   }
 
+  if (y < this.tree.options.height) {
+    // Don't bother autoscrolling if y position (i.e. the traveling node)
+    // is above the top node of the tree
+    return
+  }
+
   var node = tree.el.select('.tree').node()
     , threshold = 30
     , pixels = 10


### PR DESCRIPTION
above the top node of the tree.

For https://github.com/SpiderStrategies/Scoreboard/issues/30945