### PR TITLE
Immediately sets `node` classname on all `li` elements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,6 +354,9 @@ Tree.prototype._join = function (data, next) {
                      })
     , enter = _node.enter()
                    .insert('li')
+                   .classed('node', true) // enter should take care of this, but
+                                          // see Impact #32542. For some reason performanced tuned dnd scrolling
+                                          // causes issues. This is a hack
     , exit = _node.exit()
     , update = this.node = enter.merge(_node)
 


### PR DESCRIPTION
This should happen in the `enter` code, but I think a race condition
with autoscrolling from DND code causes issues. This is a total hack but
I couldn't figure out a better solution.

For https://github.com/SpiderStrategies/Scoreboard/issues/32542