### PR TITLE
Emits `rebind:exit` events with the exiting nodes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,6 +366,11 @@ Tree.prototype._join = function (data, next) {
     , exit = _node.exit()
     , update = this.node = enter.merge(_node)
 
+  if (exit.size()) {
+    // Nodes are being removed, trigger an event for interested parties
+    this.emit('rebind:exit', exit)
+  }
+
   if (this.el.select('.tree').classed('editable')) {
     update.filter(function (d) {
             return self.options.movable.call(self, self.nodes[d.id])

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -1161,6 +1161,25 @@ test('sets `tree-overflow` based on scrollable content', function (t) {
   tree.render()
 })
 
+test('emits `rebind:exit` with nodes being removed', function (t) {
+  t.plan(2)
+  let s = stream()
+    , tree = new Tree({stream: s})
+
+  tree.on('rebind:exit', selection => {
+    t.ok(data, 'rebind:exit called')
+    t.equal(selection.size(), 34, 'nodes removed')
+    t.end()
+  })
+
+  tree.render()
+
+  tree.on('rendered', function () {
+    tree.expandAll() // Show everything
+    tree.collapseAll() // Collapse which will remove a bunch of nodes
+  })
+})
+
 test('emits `rebind` event when rebinding data', function (t) {
   t.plan(1)
   var s = stream()


### PR DESCRIPTION
Needed for https://github.com/SpiderStrategies/record-list/issues/21
and https://github.com/SpiderStrategies/Scoreboard/issues/34174