### PR TITLE
use a default color scheme if user doesn't have access to scoreboard-colors

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -4,7 +4,7 @@ var http = require('http')
   , sass = require('node-sass')
   , request = require('request')
   , spawn = require('child_process').spawn
-  , colors = require('scoreboard-colors')
+  , renderProperties = require('../render-properties')
 
 http.createServer(function (req, res) {
   var _url = url.parse(req.url, true)
@@ -13,10 +13,7 @@ http.createServer(function (req, res) {
   if (path == '/index.html' || path == '/') {
     return fs.createReadStream(__dirname + '/index.html').pipe(res)
   } else if (path == '/tree.css') {
-    sass.render({
-        file: './style/tree.scss',
-        includePaths: colors.includePaths
-      }, function (err, result) {
+    sass.render(renderProperties, function (err, result) {
       res.writeHead(200, { 'Content-Type': 'text/css' })
         res.end(result.css)
       })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "d3-transition": "^1.0.3",
     "escape-string-regexp": "^1.0.3",
     "node-sass": "^4.9.0",
-    "scoreboard-colors": "git+ssh://git@github.com/SpiderStrategies/scoreboard-colors.git#v4.2.0"
+    "optional-require": "^1.0.3"
   },
   "devDependencies": {
     "JSONStream": "^1.0.6",
@@ -28,6 +28,9 @@
     "start": "node example/server.js",
     "test": "browserify -t browserify-css test/* | double-tap smokestack",
     "watch": "watchify -r ./index.js:tree -r http -r JSONStream -o example/bundle.js -d"
+  },
+  "optionalDependencies": {
+    "scoreboard-colors": "git+ssh://git@github.com/SpiderStrategies/scoreboard-colors.git#v4.2.0"
   },
   "repository": {
     "type": "git",

--- a/render-properties.js
+++ b/render-properties.js
@@ -1,0 +1,12 @@
+var optionalRequire = require("optional-require")(require)
+, colors = optionalRequire('scoreboard-colors')
+
+let renderProperties = {
+  file: __dirname + '/style/' + (colors ? 'scoreboard' : 'default') + '-tree.scss'
+}
+  
+if(colors) {
+  renderProperties.includePaths = colors.includePaths
+}
+ 
+module.exports = renderProperties

--- a/scripts/css.js
+++ b/scripts/css.js
@@ -1,11 +1,8 @@
 var sass = require('node-sass')
   , fs = require('fs')
-  , colors = require('scoreboard-colors')
+  , renderProperties = require('../render-properties')
 
-sass.render({
-  file: __dirname + '/../style/tree.scss',
-  includePaths: colors.includePaths
-}, function (err, result) {
+sass.render(renderProperties, function (err, result) {
   if (err) {
     throw err
   }

--- a/style/default-colors.scss
+++ b/style/default-colors.scss
@@ -1,0 +1,22 @@
+$color-true-black: #000000;
+$color-ash: #EFF3F7;
+$color-slate: #616D7A;
+$color-warning: #FBCC3C;
+$color-error: #FF4D4B;
+
+
+// Trees
+$color-tree-background: #393C40;
+$color-tree-node-text-color: #ADB8BC;
+$color-tree-node-text-shadow: rgba($color-true-black, 0.23);
+$color-tree-node-drag-handle-fill: #555A5E;
+$color-tree-node-selected-background: #2D3135;
+$color-tree-node-selected-text-color: $color-ash;
+$color-tree-node-transient-border: $color-slate;
+$color-tree-traveling-node-background: #25282D;
+$color-tree-traveling-node-shadow: rgba($color-tree-traveling-node-background,0.50);
+$color-tree-editable-highlight: #FFE593;
+
+
+
+

--- a/style/default-tree.scss
+++ b/style/default-tree.scss
@@ -1,0 +1,3 @@
+
+@import "default-colors";
+@import "tree";

--- a/style/scoreboard-tree.scss
+++ b/style/scoreboard-tree.scss
@@ -1,0 +1,3 @@
+
+@import "scoreboard-colors";
+@import "tree";

--- a/style/tree.scss
+++ b/style/tree.scss
@@ -1,4 +1,3 @@
-@import "scoreboard-colors";
 
 $delay: 300ms;
 $timing-fn: ease-out;


### PR DESCRIPTION
This worked so great I wanted to use it in a project. However, it had a dependency on a Spider Strategies only module. I don't know if you guys want it, but I modified the project so that it would optionally install the scoreboard-colors dependency and would build without it, if it wasn't available.