### PR TITLE
When a layout node changes its `parent`, also update the source node's

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ Tree.prototype._rebind = function (next) {
       .select('.tree')
       .classed('detached-root', !!this._rootOffset)
 
-  var data = this.layout(this.root)
+  var data = this.layout(this)
   this.emit('rebind', data) // Trigger an event indicating the tree data changed
   return this._join(data, next)
 }
@@ -589,6 +589,9 @@ Tree.prototype.move = function (node, to, idx, expandAncestors = true) {
     var children = (_to._allChildren || (_to._allChildren = []))
     children.splice(typeof idx === 'number' ? idx : children.length, 0, _node)
     _node.parent = _to
+
+    // Modify the source node's parentId
+    getObject(this.nodes, node).parentId = _to.id
     if (expandAncestors) {
       this._expandAncestors(_to)
     }
@@ -993,7 +996,7 @@ Tree.prototype.editable = function () {
   var tree = this.el.select('.tree')
     , self = this
   tree.classed('editable', !tree.classed('editable'))
-  this._join(this.layout(this.root), function (enter, update, exit) {
+  this._join(this.layout(this), function (enter, update, exit) {
     // Changing editable will change the tree state, e.g. clearing search results
     // so update all the collections
     enter.call(self.enter)
@@ -1174,6 +1177,8 @@ Tree.prototype._removeFromParent = function (node) {
     }
   }
   node.parent = null
+
+  delete getObject(this.nodes, node)?.parentId
 
   return this
 }

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -404,6 +404,7 @@ Dnd.prototype._move = function (y, d) {
         self.tree._rebind(function (enter, update, exit) {
           update.call(self.updater)
           exit.remove()
+
         })
       }, true, true)()
     }

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -22,12 +22,13 @@ function traverse (roots, callback) {
  * Computes the layout of the tree
  */
 export default function (depth, height, rootOffset, children) {
-  return function (root) {
+  return function (tree) {
+    let root = tree.root
     if (!root) {
       return []
     }
 
-    var roots = (Array.isArray(root) ? root : [root]).filter(function (r) {
+    let roots = (Array.isArray(root) ? root : [root]).filter(function (r) {
                   // Forest tree root nodes could have `visible: false`, so be sure to filter
                   return r.visible !== false
                 })
@@ -46,6 +47,12 @@ export default function (depth, height, rootOffset, children) {
             stack.push(child = childs[n])
             child.parent = node
             child.depth = node.depth + 1
+
+            let source = tree.nodes?.[child.id]
+            // If there's a source node, update it's parentId
+            if (source) {
+              source.parentId = node.id
+            }
           }
           node.children = childs
         } else {

--- a/test/dnd-test.js
+++ b/test/dnd-test.js
@@ -273,12 +273,15 @@ test('drag changes data', function (t) {
 
     let e1 = event('mouse')
     e1.y = 290
+
+    t.equal(tree.nodes[1004].parentId, 1003, 'original node parentId set')
     dnd.drag.apply(node, [e1, data, 3])
 
     tree.once('move', function (n, newParent, previousParent, newIndex, previousIndex) {
       t.equal(n.label, 'M1', 'moved node label is correct')
       t.equal(newParent.label, 'M5', 'moved node new parent label is correct')
       t.equal(previousParent.label, 'O1', 'moved node previous parent label is correct')
+      t.equal(tree.nodes[1004].parentId, newParent.id, 'source node parentId has changed')
       t.equal(newIndex, 0, 'new index is correct')
       t.equal(previousIndex, 0, 'previous index is correct')
       tree.remove()

--- a/test/layout-test.js
+++ b/test/layout-test.js
@@ -35,7 +35,7 @@ test('generates a forest tree', function (t) {
   var l = layout(20, 40, 0, function (d) {
             return d.children
           })
-    , nodes = l(forest)
+    , nodes = l({root: forest})
 
   t.equal(nodes.length, 8, '8 nodes in tree')
 
@@ -79,7 +79,7 @@ test('generates a forest tree with hidden roots', function (t) {
   var l = layout(20, 40, 0, function (d) {
             return d.children
           })
-    , nodes = l(forest)
+    , nodes = l({root: forest})
 
   t.equal(nodes.length, 5, '5 nodes in tree')
   t.end()
@@ -88,7 +88,7 @@ test('generates a forest tree with hidden roots', function (t) {
 test('generates an empty tree', function (t) {
   var l = layout()
   t.plan(1)
-  t.deepEqual(l(null), [], 'empty tree with null root')
+  t.deepEqual(l({root: null}), [], 'empty tree with null root')
   t.end()
 })
 
@@ -96,7 +96,7 @@ test('generates a tree layout', function (t) {
   var l = layout(20, 40, 0, function (d) {
         return d.children
       })
-    , nodes = l(tree())
+    , nodes = l({root: tree()})
 
   t.equal(nodes.length, 5, '5 nodes in tree')
   t.equal(nodes[0].depth, 0, 'root has depth 0')
@@ -120,7 +120,7 @@ test('applies a root offset', function (t) {
   var l = layout(20, 40, 10, function (d) {
         return d.children
       })
-    , nodes = l(tree())
+    , nodes = l({root: tree()})
 
   t.equal(nodes[0]._y, 0, 'root _y does not use offset')
   t.equal(nodes[1]._y, 50, 'first child includes offset')

--- a/test/tree-api-test.js
+++ b/test/tree-api-test.js
@@ -85,6 +85,7 @@ test('moves a node', function (t) {
     process.nextTick(function () {
       t.equal(orgParent._allChildren.length, orgChildrenLength - 1, 'original parent is missing a child')
       t.deepEqual(tree._layout[1003].parent, tree._layout[1025], 'moved node has new parent')
+      t.deepEqual(tree.nodes[1003].parentId, 1025, 'original node parentId was modified')
       t.equal(tree._layout[1003].parent.children.length, 5, 'new parent is expanded')
       t.deepEqual(tree._layout[1025]._allChildren[tree._layout[1025]._allChildren.length -1], tree._layout[1003], '1003 was pushed to end of 1025')
       t.end()


### PR DESCRIPTION
parentid.

The source node is the incoming node that is used by the caller.

Related to https://github.com/SpiderStrategies/Scoreboard/issues/55478 Also see discussions in https://github.com/SpiderStrategies/Scoreboard/pull/55500