### PR TITLE
Issue #479: Node width

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -43,7 +43,8 @@ export default function (tree) {
               .call(tree.options.contents, tree)
               .select(tree.options.indentableSelector)
               .attr('style', function (d) {
-                return tree.prefix + 'transform:' + 'translate(' + tree._rtlTransformX(d._x) + 'px,0px)'
+                let indentValue = `${tree._rtlTransformX(d._x)}px`
+                return tree.prefix + `transform: translate(${indentValue}, 0px); width: calc(100% - ${indentValue})`
               })
 
     // If the tree has indicators, we may need to update the color


### PR DESCRIPTION
@nathanbowser Any thoughts on this change? This gets it working well for what I need.

Here's how the highlight portion looks after this change:

<img width="551" alt="Screenshot 2024-01-31 at 3 57 55 PM" src="https://github.com/SpiderStrategies/kalpa-tree/assets/3791116/461498fc-5f38-4dcc-b65e-2769aa9dd15f">

I'd like to get the fix in so the trees aren't so ugly while i'm working on them ha.

fixes #479