### PR TITLE
Removes `moz` styles prefix for firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import contents from './lib/contents.js'
 
 const styles = window.getComputedStyle(document.documentElement, '')
     , identity = v => f
-    , prefix = Array.prototype.slice.call(styles).join('').match(/-(moz|webkit|ms)-/)[0]
+    , prefix = Array.prototype.slice.call(styles).join('').match(/-(webkit|ms)-/)[0]
 
 // Mix transitions into d3-selection's prototype
 import 'd3-transition'

--- a/style/tree.scss
+++ b/style/tree.scss
@@ -233,7 +233,7 @@ $tree-item-height: 36px;
     width: 100%;
     height: 100%;
 
-    @include prefix(user-select, none, webkit moz ms);
+    @include prefix(user-select, none, webkit ms);
 
     // Most tree functions that modify the dom send a callback into transitionWrap where has some magic
     // to determine whether or not we actually want transitions. It's in charge of adding the .transitions


### PR DESCRIPTION
Apparently no longer needed (or supported)

For https://github.com/SpiderStrategies/Scoreboard/issues/58126