### PR TITLE
Fixes a blowup if a browser doesn't declare webkit or moz styles.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ import layout from './lib/layout.js'
 import contents from './lib/contents.js'
 
 const styles = window.getComputedStyle(document.documentElement, '')
-    , identity = v => f
-    , prefix = Array.prototype.slice.call(styles).join('').match(/-(webkit|ms)-/)[0]
+    , identity = v => v
+    , matchResult = Array.prototype.slice.call(styles).join('').match(/-(webkit|ms)-/)
+    , prefix = matchResult ? matchResult[0] : ''
 
 // Mix transitions into d3-selection's prototype
 import 'd3-transition'


### PR DESCRIPTION
This is needed in a test suite for record-list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the identity function to properly return its input value.
	- Improved CSS prefix extraction to prevent errors when no match is found, enhancing app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->